### PR TITLE
[codex] Refactor shell view model composition

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.Behaviors.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.Behaviors.cs
@@ -173,7 +173,7 @@ public sealed partial class MainViewModel : ViewModelBase
             showFirstRunPreparationOverlay = await ShouldShowFirstRunPreparationOverlayAsync(cancellationToken);
             if (showFirstRunPreparationOverlay)
             {
-                IsFirstRunPreparationOverlayVisible = true;
+                StartupOverlay.ApplyFirstRunPreparationOverlay(true);
                 LogInfo(MainViewModelLogCategories.App, "milestone startup_overlay_shown");
                 coverCacheBootstrapCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 coverCacheBootstrapTask = StartCoverCacheBootstrapForColdStartAsync(coverCacheBootstrapCancellation.Token);
@@ -217,7 +217,7 @@ public sealed partial class MainViewModel : ViewModelBase
                     coverCacheBootstrapCancellation,
                     archiveWarmupState,
                     archiveReadinessResult);
-                IsFirstRunPreparationOverlayVisible = false;
+                StartupOverlay.ApplyFirstRunPreparationOverlay(false);
                 LogInfo(MainViewModelLogCategories.App, "milestone first_run_overlay_hidden");
                 await CompleteFirstRunPreparationOverlayAsync(
                     archiveWarmupState,
@@ -975,12 +975,6 @@ public sealed partial class MainViewModel : ViewModelBase
     private void ApplyRuntimeSummaryStateUpdate(RuntimeSummaryStateUpdate update)
     {
         _runtimeShellState.ApplyRuntimeSummary(update);
-        DeviceText = update.DeviceText;
-        GpuText = update.GpuText;
-        GpuLogoSource = update.GpuLogoSource;
-        GpuLogoWidth = update.GpuLogoWidth;
-        GpuLogoHeight = update.GpuLogoHeight;
-        GpuLogoMargin = update.GpuLogoMargin;
         RuntimeHeader.Apply(update);
 
         if (update.HasSelectedGpu)
@@ -990,7 +984,7 @@ public sealed partial class MainViewModel : ViewModelBase
                 $"selected_gpu vendor={NormalizeStatusCode(update.SelectedGpuVendor, MainViewModelStatusCodes.Unknown)} name=\"{NormalizeStatusCode(update.SelectedGpuName, MainViewModelStatusCodes.Unknown)}\" source={NormalizeStatusCode(_gpuSelectionCoordinator.SelectedGpuLogSource, "runtime_context_selected")}");
             LogInfo(
                 MainViewModelLogCategories.Runtime,
-                $"gpu_logo source={(string.IsNullOrWhiteSpace(GpuLogoSource) ? "none" : NormalizeStatusCode(GpuLogoSource, "none"))}");
+                $"gpu_logo source={(string.IsNullOrWhiteSpace(update.GpuLogoSource) ? "none" : NormalizeStatusCode(update.GpuLogoSource, "none"))}");
         }
         else
         {

--- a/OptiClick.Wpf/ViewModels/MainViewModel.Commands.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.Commands.cs
@@ -1,86 +1,37 @@
 using System.Windows.Input;
-using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.ViewModels.Shell;
 
 namespace OptiClick.Wpf.ViewModels;
 
 public sealed partial class MainViewModel
 {
-    private sealed record MainViewModelCommandSet
-    {
-        public required ICommand SelectGameCommand { get; init; }
-        public required ICommand ShowHomeCommand { get; init; }
-        public required ICommand ShowSupportedGamesWikiViewCommand { get; init; }
-        public required ICommand ShowScanViewCommand { get; init; }
-        public required ICommand ShowSettingsCommand { get; init; }
-        public required ICommand AddScanFolderCommand { get; init; }
-        public required ICommand RemoveScanFolderCommand { get; init; }
-        public required ICommand OpenScanFolderCommand { get; init; }
-        public required ICommand SaveAndScanCommand { get; init; }
-        public required ICommand OpenLogFolderCommand { get; init; }
-        public required ICommand OpenSupportRequestCommand { get; init; }
-        public required ICommand OpenGameSupportRequestCommand { get; init; }
-        public required ICommand RefreshInstallFilesCommand { get; init; }
-        public required ICommand ShowDetailsCommand { get; init; }
-        public required ICommand ShowInstallCommand { get; init; }
-    }
+    private RelayCommand _openGameSupportRequestCommand = null!;
 
-    private MainViewModelCommandSet? _commandSet;
-    private RelayCommand _showHomeCommand = null!;
-    private RelayCommand _showSupportedGamesWikiCommand = null!;
-    private RelayCommand _showSettingsCommand = null!;
-    private AsyncRelayCommand _saveAndScanCommand = null!;
-
-    public ICommand SelectGameCommand => _commandSet!.SelectGameCommand;
-    public ICommand ShowHomeCommand => _commandSet!.ShowHomeCommand;
-    public ICommand ShowSupportedGamesWikiViewCommand => _commandSet!.ShowSupportedGamesWikiViewCommand;
-    public ICommand ShowScanViewCommand => _commandSet!.ShowScanViewCommand;
-    public ICommand ShowSettingsCommand => _commandSet!.ShowSettingsCommand;
-    public ICommand AddScanFolderCommand => _commandSet!.AddScanFolderCommand;
-    public ICommand RemoveScanFolderCommand => _commandSet!.RemoveScanFolderCommand;
-    public ICommand OpenScanFolderCommand => _commandSet!.OpenScanFolderCommand;
-    public ICommand SaveAndScanCommand => _commandSet!.SaveAndScanCommand;
-    public ICommand OpenLogFolderCommand => _commandSet!.OpenLogFolderCommand;
-    public ICommand OpenSupportRequestCommand => _commandSet!.OpenSupportRequestCommand;
-    public ICommand OpenGameSupportRequestCommand => _commandSet!.OpenGameSupportRequestCommand;
-    public ICommand RefreshInstallFilesCommand => _commandSet!.RefreshInstallFilesCommand;
-    public ICommand ShowDetailsCommand => _commandSet!.ShowDetailsCommand;
-    public ICommand ShowInstallCommand => _commandSet!.ShowInstallCommand;
+    public ICommand SelectGameCommand => Home.SelectGameCommand;
+    public ICommand ShowHomeCommand => Commands.ShowHomeCommand;
+    public ICommand ShowSupportedGamesWikiViewCommand => Commands.ShowSupportedGamesWikiViewCommand;
+    public ICommand ShowScanViewCommand => Commands.ShowScanViewCommand;
+    public ICommand ShowSettingsCommand => Commands.ShowSettingsCommand;
+    public ICommand AddScanFolderCommand => Scan.AddScanFolderCommand;
+    public ICommand RemoveScanFolderCommand => Scan.RemoveScanFolderCommand;
+    public ICommand OpenScanFolderCommand => Scan.OpenScanFolderCommand;
+    public ICommand SaveAndScanCommand => Scan.SaveAndScanCommand;
+    public ICommand OpenLogFolderCommand => Settings.OpenLogFolderCommand;
+    public ICommand OpenSupportRequestCommand => Settings.OpenSupportRequestCommand;
+    public ICommand OpenGameSupportRequestCommand => _openGameSupportRequestCommand;
+    public ICommand RefreshInstallFilesCommand => Settings.RefreshInstallFilesCommand;
+    public ICommand ShowDetailsCommand => Home.ShowDetailsCommand;
+    public ICommand ShowInstallCommand => Home.ShowInstallCommand;
 
     private void InitializeCommandSet()
     {
-        _showHomeCommand = new RelayCommand(
-            _ => SetCurrentView(ShellViewKind.Home));
-        _showSupportedGamesWikiCommand = new RelayCommand(
-            _ => SetCurrentView(ShellViewKind.SupportedGamesWiki));
-        _showSettingsCommand = new RelayCommand(
-            _ => SetCurrentView(ShellViewKind.Settings));
-        _saveAndScanCommand = Scan.SaveAndScanCommand;
-
-        _commandSet = new MainViewModelCommandSet
-        {
-            SelectGameCommand = Home.SelectGameCommand,
-            ShowHomeCommand = _showHomeCommand,
-            ShowSupportedGamesWikiViewCommand = _showSupportedGamesWikiCommand,
-            ShowScanViewCommand = new RelayCommand(_ => ShowScanView()),
-            ShowSettingsCommand = _showSettingsCommand,
-            AddScanFolderCommand = Scan.AddScanFolderCommand,
-            RemoveScanFolderCommand = Scan.RemoveScanFolderCommand,
-            OpenScanFolderCommand = Scan.OpenScanFolderCommand,
-            SaveAndScanCommand = _saveAndScanCommand,
-            OpenLogFolderCommand = Settings.OpenLogFolderCommand,
-            OpenSupportRequestCommand = Settings.OpenSupportRequestCommand,
-            OpenGameSupportRequestCommand = new RelayCommand(_ => OpenGameSupportRequest()),
-            RefreshInstallFilesCommand = Settings.RefreshInstallFilesCommand,
-            ShowDetailsCommand = Home.ShowDetailsCommand,
-            ShowInstallCommand = Home.ShowInstallCommand
-        };
+        Commands = new ShellCommandsViewModel(SetCurrentView, ShowScanView);
+        _openGameSupportRequestCommand = new RelayCommand(_ => OpenGameSupportRequest());
     }
 
     private void RefreshNavigationAndScanCommandStates()
     {
-        _showHomeCommand?.RaiseCanExecuteChanged();
-        _showSupportedGamesWikiCommand?.RaiseCanExecuteChanged();
-        _showSettingsCommand?.RaiseCanExecuteChanged();
+        Commands?.RefreshNavigationCommandStates();
         Scan?.RefreshCommandStates();
         Home?.RefreshCommandStates();
     }

--- a/OptiClick.Wpf/ViewModels/MainViewModel.InstallAndState.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.InstallAndState.cs
@@ -469,8 +469,13 @@ public sealed partial class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(update);
         if (!string.IsNullOrWhiteSpace(update.ScanStatusText)) ScanStatusText = update.ScanStatusText;
         if (!string.IsNullOrWhiteSpace(update.SettingsStatusText)) SettingsStatusText = update.SettingsStatusText;
-        if (!string.IsNullOrWhiteSpace(update.DeviceText)) DeviceText = update.DeviceText;
-        if (!string.IsNullOrWhiteSpace(update.GpuText)) GpuText = update.GpuText;
+        if (!string.IsNullOrWhiteSpace(update.DeviceText) || !string.IsNullOrWhiteSpace(update.GpuText))
+        {
+            RuntimeHeader.ApplyText(
+                string.IsNullOrWhiteSpace(update.DeviceText) ? RuntimeHeader.DeviceText : update.DeviceText,
+                string.IsNullOrWhiteSpace(update.GpuText) ? RuntimeHeader.GpuText : update.GpuText);
+        }
+
         if (update.ShouldRelocalizeScanFolders) RelocalizeScanFolderRows();
         if (update.ShouldRefreshRuntimeSummary) ApplyRuntimeSummaryStateUpdate(_runtimeSummaryStateController.Build(_runtimeShellState.LatestRuntimeContext, Strings));
     }

--- a/OptiClick.Wpf/ViewModels/MainViewModel.ShellAndUpdate.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.ShellAndUpdate.cs
@@ -205,8 +205,7 @@ public sealed partial class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(update);
         _isAppUpdateInProgress = update.IsAppUpdateInProgress;
         _isInstallExecutionInProgress = update.IsInstallExecutionInProgress;
-        IsOperationOverlayVisible = update.IsOperationOverlayVisible;
-        OperationOverlayMessage = update.OperationOverlayMessage;
+        ShellBusyState.Apply(update.IsOperationOverlayVisible, update.OperationOverlayMessage);
         if (!string.IsNullOrWhiteSpace(update.SettingsStatusText)) SettingsStatusText = update.SettingsStatusText;
         if (update.ShouldRefreshInstallCommand)
         {

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -36,6 +36,7 @@ using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Update;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Home;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
 using OptiClick.Wpf.ViewModels.Sections.Settings;
@@ -124,15 +125,6 @@ public sealed partial class MainViewModel : ViewModelBase
     private readonly AppLanguage _systemPreferredLanguage = AppLanguage.English;
     private AppLanguage _selectedLanguage = AppLanguage.English;
     private string _languagePreference = LanguagePreferenceAuto;
-    private string _deviceText = "";
-    private string _gpuText = "";
-    private string _gpuLogoSource = "";
-    private double _gpuLogoWidth;
-    private double _gpuLogoHeight;
-    private Thickness _gpuLogoMargin = new(0);
-    private bool _isFirstRunPreparationOverlayVisible;
-    private bool _isOperationOverlayVisible;
-    private string _operationOverlayMessage = "";
     private StartupPreparationState _startupPreparationState = StartupPreparationState.Empty;
 
     // Runtime state
@@ -256,12 +248,11 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
-        Home = new HomeSectionViewModel(
-            new HomeSectionViewModelOptions
+        var sections = new ShellSectionsFactory().Create(
+            new ShellSectionsFactoryInput
             {
                 StringsAccessor = () => Strings,
                 Games = games,
-                SelectedGameAction = new SelectedGameActionViewModel(),
                 SelectGameAsync = (game, cancellationToken) => SelectGameCardAsync(game, cancellationToken),
                 ShowDetails = ShowDetailsDialog,
                 ShowInstallAsync = ShowInstallDialogAsync,
@@ -272,22 +263,7 @@ public sealed partial class MainViewModel : ViewModelBase
                                       && !_isAppUpdateInProgress
                                       && !ShouldBlockStartupForUnsupportedOperatingSystem(),
                 OnSelectGameException = ex => LogError(MainViewModelLogCategories.Command, "select game command failed", ex),
-                OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex)
-            });
-        Home.PropertyChanged += OnHomeSectionPropertyChanged;
-        SupportedGames = new SupportedGamesSectionViewModel(
-            supportedGamesWikiMarkdownLoader,
-            _startupBackgroundTaskManager,
-            _appLogger,
-            () => SelectedLanguage,
-            () => Strings,
-            () => CurrentViewKind == ShellViewKind.SupportedGamesWiki,
-            () => OpenGameSupportRequestCommand,
-            UpdateStartupPreparationState);
-        Scan = new ScanSectionViewModel(
-            new ScanSectionViewModelOptions
-            {
-                StringsAccessor = () => Strings,
+                OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex),
                 DefaultFolders = defaultFolders,
                 AddedFolders = addedFolders,
                 ScanFolderListController = scanFolderListController,
@@ -305,31 +281,35 @@ public sealed partial class MainViewModel : ViewModelBase
                 ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
                 ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
                 ClearVisibleGameCards = () => ReplaceGameCards([]),
-                LogWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
+                LogScanWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
                 ShowHome = () => SetCurrentView(ShellViewKind.Home),
                 AddedFolderStatusBrush = AddedFolderStatusBrush,
                 MissingFolderStatusBrush = MissingFolderStatusBrush,
-                OnCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex)
-            });
-        Scan.PropertyChanged += OnScanSectionPropertyChanged;
-        var settingsActionCoordinator = new SettingsActionCoordinator(
-            _dialogPresenter,
-            _localDataPathProvider,
-            _appLogger);
-        Settings = new SettingsSectionViewModel(
-            new SettingsSectionViewModelOptions
-            {
-                StringsAccessor = () => Strings,
+                OnScanCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex),
+                SupportedGamesWikiMarkdownLoader = supportedGamesWikiMarkdownLoader,
+                StartupBackgroundTaskManager = _startupBackgroundTaskManager,
+                AppLogger = _appLogger,
+                SelectedLanguageAccessor = () => SelectedLanguage,
+                CurrentViewKindAccessor = () => CurrentViewKind,
+                OpenGameSupportRequestCommandAccessor = () => OpenGameSupportRequestCommand,
+                UpdateStartupPreparationState = UpdateStartupPreparationState,
+                LocalDataPathProvider = _localDataPathProvider,
                 IsKoreanUi = () => IsKoreanUi,
                 SettingsLanguageOptions = settingsLanguageOptions,
                 InitialSettingsLanguageOption = LanguageOptionAuto,
                 ApplySettingsLanguageOption = ApplySettingsLanguageOption,
-                SettingsActionCoordinator = settingsActionCoordinator,
                 IsInstallExecutionInProgress = () => _isInstallExecutionInProgress,
-                OpenLogFolderCommand = new RelayCommand(_ => OpenLogFolder()),
-                OpenSupportRequestCommand = new RelayCommand(_ => OpenSupportRequest()),
+                OpenLogFolder = OpenLogFolder,
+                OpenSupportRequest = OpenSupportRequest,
                 OnRefreshInstallFilesException = ex => LogError(MainViewModelLogCategories.Command, "reset app cache command failed", ex)
             });
+
+        Home = sections.Home;
+        Home.PropertyChanged += OnHomeSectionPropertyChanged;
+        SupportedGames = sections.SupportedGames;
+        Scan = sections.Scan;
+        Scan.PropertyChanged += OnScanSectionPropertyChanged;
+        Settings = sections.Settings;
         Settings.PropertyChanged += OnSettingsSectionPropertyChanged;
         InitializeCommandSet();
 
@@ -341,8 +321,8 @@ public sealed partial class MainViewModel : ViewModelBase
             Strings,
             SettingsStatusText,
             ScanStatusText,
-            _deviceText,
-            _gpuText));
+            RuntimeHeader.DeviceText,
+            RuntimeHeader.GpuText));
         ApplyUserSettings(_userSettingsController.Load());
     }
 
@@ -398,6 +378,7 @@ public sealed partial class MainViewModel : ViewModelBase
     public RuntimeHeaderViewModel RuntimeHeader { get; }
     public StartupOverlayViewModel StartupOverlay { get; }
     public ShellBusyStateViewModel ShellBusyState { get; }
+    public ShellCommandsViewModel Commands { get; private set; } = null!;
     public HomeSectionViewModel Home { get; }
     public ScanSectionViewModel Scan { get; }
     public SupportedGamesSectionViewModel SupportedGames { get; }
@@ -419,90 +400,6 @@ public sealed partial class MainViewModel : ViewModelBase
         get => _strings;
         private set => SetProperty(ref _strings, value);
     }
-    public string DeviceText
-    {
-        get => _deviceText;
-        private set
-        {
-            if (SetProperty(ref _deviceText, value))
-            {
-                OnPropertyChanged(nameof(DeviceGpuInlineText));
-                RuntimeHeader.ApplyText(DeviceText, GpuText);
-            }
-        }
-    }
-
-    public string GpuText
-    {
-        get => _gpuText;
-        private set
-        {
-            if (SetProperty(ref _gpuText, value))
-            {
-                OnPropertyChanged(nameof(DeviceGpuInlineText));
-                RuntimeHeader.ApplyText(DeviceText, GpuText);
-            }
-        }
-    }
-
-    public string DeviceGpuInlineText
-    {
-        get
-        {
-            var device = (DeviceText ?? "").Trim();
-            var gpu = (GpuText ?? "").Trim();
-
-            if (string.IsNullOrWhiteSpace(device) && string.IsNullOrWhiteSpace(gpu))
-            {
-                return "";
-            }
-
-            if (string.IsNullOrWhiteSpace(device))
-            {
-                return gpu;
-            }
-
-            if (string.IsNullOrWhiteSpace(gpu))
-            {
-                return device;
-            }
-
-            return $"{device} | {gpu}";
-        }
-    }
-
-    public string GpuLogoSource
-    {
-        get => _gpuLogoSource;
-        private set
-        {
-            if (SetProperty(ref _gpuLogoSource, value))
-            {
-                OnPropertyChanged(nameof(GpuLogoVisibility));
-            }
-        }
-    }
-
-    public Visibility GpuLogoVisibility =>
-        string.IsNullOrWhiteSpace(GpuLogoSource) ? Visibility.Collapsed : Visibility.Visible;
-
-    public double GpuLogoWidth
-    {
-        get => _gpuLogoWidth;
-        private set => SetProperty(ref _gpuLogoWidth, value);
-    }
-
-    public double GpuLogoHeight
-    {
-        get => _gpuLogoHeight;
-        private set => SetProperty(ref _gpuLogoHeight, value);
-    }
-
-    public Thickness GpuLogoMargin
-    {
-        get => _gpuLogoMargin;
-        private set => SetProperty(ref _gpuLogoMargin, value);
-    }
     public ShellViewKind CurrentViewKind => _navigationState.CurrentView;
     public bool IsHomeViewActive => CurrentViewKind == ShellViewKind.Home;
     public bool IsSupportedGamesWikiViewActive => CurrentViewKind == ShellViewKind.SupportedGamesWiki;
@@ -517,45 +414,6 @@ public sealed partial class MainViewModel : ViewModelBase
     public Visibility SupportedGamesWikiStatusVisibility => SupportedGames.SupportedGamesWikiStatusVisibility;
     public Visibility SupportedGamesWikiLoadingVisibility => SupportedGames.SupportedGamesWikiLoadingVisibility;
     public Visibility SupportedGamesWikiEmptyVisibility => SupportedGames.SupportedGamesWikiEmptyVisibility;
-    public Visibility FirstRunPreparationOverlayVisibility =>
-        IsFirstRunPreparationOverlayVisible ? Visibility.Visible : Visibility.Collapsed;
-    public bool IsFirstRunPreparationOverlayVisible
-    {
-        get => _isFirstRunPreparationOverlayVisible;
-        private set
-        {
-            if (SetProperty(ref _isFirstRunPreparationOverlayVisible, value))
-            {
-                OnPropertyChanged(nameof(FirstRunPreparationOverlayVisibility));
-                StartupOverlay.ApplyFirstRunPreparationOverlay(value);
-            }
-        }
-    }
-    public Visibility OperationOverlayVisibility =>
-        IsOperationOverlayVisible ? Visibility.Visible : Visibility.Collapsed;
-    public bool IsOperationOverlayVisible
-    {
-        get => _isOperationOverlayVisible;
-        private set
-        {
-            if (SetProperty(ref _isOperationOverlayVisible, value))
-            {
-                OnPropertyChanged(nameof(OperationOverlayVisibility));
-                ShellBusyState.Apply(IsOperationOverlayVisible, OperationOverlayMessage);
-            }
-        }
-    }
-    public string OperationOverlayMessage
-    {
-        get => _operationOverlayMessage;
-        private set
-        {
-            if (SetProperty(ref _operationOverlayMessage, value))
-            {
-                ShellBusyState.Apply(IsOperationOverlayVisible, OperationOverlayMessage);
-            }
-        }
-    }
     public string SupportedGamesWikiEmptyText => SupportedGames.SupportedGamesWikiEmptyText;
     public bool IsSupportedGamesWikiLoading => SupportedGames.IsSupportedGamesWikiLoading;
     public Visibility DefaultFoldersEmptyVisibility => Scan.DefaultFoldersEmptyVisibility;

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
@@ -1,0 +1,182 @@
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Media;
+using OptiClick.Core.Runtime;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Logging;
+using OptiClick.Wpf.Models;
+using OptiClick.Wpf.Services;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.Shell.RuntimeData;
+using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.Shell.Settings;
+using OptiClick.Wpf.Shell.Startup;
+using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections.Home;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Sections.Settings;
+using OptiClick.Wpf.ViewModels.Sections.SupportedGames;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed class ShellSectionsFactory
+{
+    public ShellSections Create(ShellSectionsFactoryInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new ShellSections(
+            CreateHome(input),
+            CreateScan(input),
+            CreateSupportedGames(input),
+            CreateSettings(input));
+    }
+
+    private static HomeSectionViewModel CreateHome(ShellSectionsFactoryInput input)
+    {
+        return new HomeSectionViewModel(
+            new HomeSectionViewModelOptions
+            {
+                StringsAccessor = input.StringsAccessor,
+                Games = input.Games,
+                SelectedGameAction = new SelectedGameActionViewModel(),
+                SelectGameAsync = input.SelectGameAsync,
+                ShowDetails = input.ShowDetails,
+                ShowInstallAsync = input.ShowInstallAsync,
+                CanSelectGame = input.CanSelectGame,
+                CanShowDetails = input.CanShowDetails,
+                CanShowInstall = input.CanShowInstall,
+                OnSelectGameException = input.OnSelectGameException,
+                OnShowInstallException = input.OnShowInstallException
+            });
+    }
+
+    private static ScanSectionViewModel CreateScan(ShellSectionsFactoryInput input)
+    {
+        return new ScanSectionViewModel(
+            new ScanSectionViewModelOptions
+            {
+                StringsAccessor = input.StringsAccessor,
+                DefaultFolders = input.DefaultFolders,
+                AddedFolders = input.AddedFolders,
+                ScanFolderListController = input.ScanFolderListController,
+                ScanFolderActionController = input.ScanFolderActionController,
+                ApplyScanFolderActionResult = input.ApplyScanFolderActionResult,
+                ScanFlowController = input.ScanFlowController,
+                ScanLock = input.ScanLock,
+                ScannedGameState = input.ScannedGameState,
+                DialogPresenter = input.DialogPresenter,
+                IsMultiGpuBlocked = input.IsMultiGpuBlocked,
+                BuildScanRequest = input.BuildScanRequest,
+                ApplyScanFlowResultAsync = input.ApplyScanFlowResultAsync,
+                RunWithStartupAutoSelectionSuppressedAsync = input.RunWithStartupAutoSelectionSuppressedAsync,
+                ApplyStartupNoGamesNavigation = input.ApplyStartupNoGamesNavigation,
+                ShowStartupNoSupportedGamesGuidanceAsync = input.ShowStartupNoSupportedGamesGuidanceAsync,
+                ClearVisibleGameCards = input.ClearVisibleGameCards,
+                LogWarning = input.LogScanWarning,
+                ShowHome = input.ShowHome,
+                AddedFolderStatusBrush = input.AddedFolderStatusBrush,
+                MissingFolderStatusBrush = input.MissingFolderStatusBrush,
+                OnCommandException = input.OnScanCommandException
+            });
+    }
+
+    private static SupportedGamesSectionViewModel CreateSupportedGames(ShellSectionsFactoryInput input)
+    {
+        return new SupportedGamesSectionViewModel(
+            input.SupportedGamesWikiMarkdownLoader,
+            input.StartupBackgroundTaskManager,
+            input.AppLogger,
+            input.SelectedLanguageAccessor,
+            input.StringsAccessor,
+            () => input.CurrentViewKindAccessor() == ShellViewKind.SupportedGamesWiki,
+            input.OpenGameSupportRequestCommandAccessor,
+            input.UpdateStartupPreparationState);
+    }
+
+    private static SettingsSectionViewModel CreateSettings(ShellSectionsFactoryInput input)
+    {
+        var settingsActionCoordinator = new SettingsActionCoordinator(
+            input.DialogPresenter,
+            input.LocalDataPathProvider,
+            input.AppLogger);
+
+        return new SettingsSectionViewModel(
+            new SettingsSectionViewModelOptions
+            {
+                StringsAccessor = input.StringsAccessor,
+                IsKoreanUi = input.IsKoreanUi,
+                SettingsLanguageOptions = input.SettingsLanguageOptions,
+                InitialSettingsLanguageOption = input.InitialSettingsLanguageOption,
+                ApplySettingsLanguageOption = input.ApplySettingsLanguageOption,
+                SettingsActionCoordinator = settingsActionCoordinator,
+                IsInstallExecutionInProgress = input.IsInstallExecutionInProgress,
+                OpenLogFolderCommand = new RelayCommand(_ => input.OpenLogFolder()),
+                OpenSupportRequestCommand = new RelayCommand(_ => input.OpenSupportRequest()),
+                OnRefreshInstallFilesException = input.OnRefreshInstallFilesException
+            });
+    }
+}
+
+public sealed record ShellSections(
+    HomeSectionViewModel Home,
+    ScanSectionViewModel Scan,
+    SupportedGamesSectionViewModel SupportedGames,
+    SettingsSectionViewModel Settings);
+
+public sealed record ShellSectionsFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required ObservableCollection<GameCardViewModel> Games { get; init; }
+    public required Func<GameCardViewModel, CancellationToken, Task> SelectGameAsync { get; init; }
+    public required Action ShowDetails { get; init; }
+    public required Func<CancellationToken, Task> ShowInstallAsync { get; init; }
+    public required Func<bool> CanSelectGame { get; init; }
+    public required Func<bool> CanShowDetails { get; init; }
+    public required Func<bool> CanShowInstall { get; init; }
+    public Action<Exception>? OnSelectGameException { get; init; }
+    public Action<Exception>? OnShowInstallException { get; init; }
+
+    public required ObservableCollection<ScanFolderRowViewModel> DefaultFolders { get; init; }
+    public required ObservableCollection<ScanFolderRowViewModel> AddedFolders { get; init; }
+    public required ScanFolderListController ScanFolderListController { get; init; }
+    public required ScanFolderActionController ScanFolderActionController { get; init; }
+    public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
+    public required ScanFlowController ScanFlowController { get; init; }
+    public required SemaphoreSlim ScanLock { get; init; }
+    public required ScannedGameState ScannedGameState { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required Func<bool> IsMultiGpuBlocked { get; init; }
+    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
+    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
+    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
+    public required Action ClearVisibleGameCards { get; init; }
+    public required Action<string> LogScanWarning { get; init; }
+    public required Action ShowHome { get; init; }
+    public required Brush AddedFolderStatusBrush { get; init; }
+    public required Brush MissingFolderStatusBrush { get; init; }
+    public Action<Exception>? OnScanCommandException { get; init; }
+
+    public required ISupportedGamesWikiMarkdownLoader SupportedGamesWikiMarkdownLoader { get; init; }
+    public required StartupBackgroundTaskManager StartupBackgroundTaskManager { get; init; }
+    public required IAppLogger AppLogger { get; init; }
+    public required Func<AppLanguage> SelectedLanguageAccessor { get; init; }
+    public required Func<ShellViewKind> CurrentViewKindAccessor { get; init; }
+    public required Func<ICommand> OpenGameSupportRequestCommandAccessor { get; init; }
+    public required Action<Func<StartupPreparationState, StartupPreparationState>> UpdateStartupPreparationState { get; init; }
+
+    public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
+    public required Func<bool> IsKoreanUi { get; init; }
+    public required ObservableCollection<string> SettingsLanguageOptions { get; init; }
+    public required string InitialSettingsLanguageOption { get; init; }
+    public required Action<string> ApplySettingsLanguageOption { get; init; }
+    public required Func<bool> IsInstallExecutionInProgress { get; init; }
+    public required Action OpenLogFolder { get; init; }
+    public required Action OpenSupportRequest { get; init; }
+    public Action<Exception>? OnRefreshInstallFilesException { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Shell/ShellCommandsViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/Shell/ShellCommandsViewModel.cs
@@ -1,0 +1,41 @@
+using System.Windows.Input;
+using OptiClick.Wpf.Shell.Navigation;
+
+namespace OptiClick.Wpf.ViewModels.Shell;
+
+public sealed class ShellCommandsViewModel
+{
+    private readonly RelayCommand _showHomeCommand;
+    private readonly RelayCommand _showSupportedGamesWikiCommand;
+    private readonly RelayCommand _showScanViewCommand;
+    private readonly RelayCommand _showSettingsCommand;
+
+    public ShellCommandsViewModel(
+        Action<ShellViewKind> setCurrentView,
+        Action showScanView)
+    {
+        ArgumentNullException.ThrowIfNull(setCurrentView);
+        ArgumentNullException.ThrowIfNull(showScanView);
+
+        _showHomeCommand = new RelayCommand(_ => setCurrentView(ShellViewKind.Home));
+        _showSupportedGamesWikiCommand = new RelayCommand(_ => setCurrentView(ShellViewKind.SupportedGamesWiki));
+        _showScanViewCommand = new RelayCommand(_ => showScanView());
+        _showSettingsCommand = new RelayCommand(_ => setCurrentView(ShellViewKind.Settings));
+    }
+
+    public ICommand ShowHomeCommand => _showHomeCommand;
+
+    public ICommand ShowSupportedGamesWikiViewCommand => _showSupportedGamesWikiCommand;
+
+    public ICommand ShowScanViewCommand => _showScanViewCommand;
+
+    public ICommand ShowSettingsCommand => _showSettingsCommand;
+
+    public void RefreshNavigationCommandStates()
+    {
+        _showHomeCommand.RaiseCanExecuteChanged();
+        _showSupportedGamesWikiCommand.RaiseCanExecuteChanged();
+        _showScanViewCommand.RaiseCanExecuteChanged();
+        _showSettingsCommand.RaiseCanExecuteChanged();
+    }
+}

--- a/OptiClick.Wpf/Views/MainWindow.xaml
+++ b/OptiClick.Wpf/Views/MainWindow.xaml
@@ -206,7 +206,7 @@
 
                     <StackPanel Grid.Row="0"
                                 Margin="8,3,8,0">
-                        <ui:Button Command="{Binding ShowHomeCommand}"
+                        <ui:Button Command="{Binding Commands.ShowHomeCommand}"
                                    Tag="{Binding IsHomeViewActive}"
                                    ToolTip="{Binding Strings.NavHome}"
                                    AutomationProperties.Name="{Binding Strings.NavHome}"
@@ -222,7 +222,7 @@
                                            Height="26" />
                         </ui:Button>
 
-                        <ui:Button Command="{Binding ShowScanViewCommand}"
+                        <ui:Button Command="{Binding Commands.ShowScanViewCommand}"
                                    Tag="{Binding IsScanViewActive}"
                                    ToolTip="{Binding Strings.NavScan}"
                                    AutomationProperties.Name="{Binding Strings.NavScan}"
@@ -238,7 +238,7 @@
                                            Height="26" />
                         </ui:Button>
 
-                        <ui:Button Command="{Binding ShowSupportedGamesWikiViewCommand}"
+                        <ui:Button Command="{Binding Commands.ShowSupportedGamesWikiViewCommand}"
                                    Tag="{Binding IsSupportedGamesWikiViewActive}"
                                    ToolTip="{Binding Strings.NavSupportedGamesWiki}"
                                    AutomationProperties.Name="{Binding Strings.NavSupportedGamesWiki}"
@@ -256,7 +256,7 @@
                     </StackPanel>
 
                     <ui:Button Grid.Row="1"
-                               Command="{Binding ShowSettingsCommand}"
+                               Command="{Binding Commands.ShowSettingsCommand}"
                                Tag="{Binding IsSettingsViewActive}"
                                ToolTip="{Binding Strings.NavSettings}"
                                AutomationProperties.Name="{Binding Strings.NavSettings}"


### PR DESCRIPTION
## Summary

- Move section view-model construction into `ShellSectionsFactory`.
- Move shell navigation commands into `ShellCommandsViewModel` and bind the side rail through `Commands.*`.
- Let `RuntimeHeader`, `StartupOverlay`, and `ShellBusyState` own their display state instead of duplicating proxy state on `MainViewModel`.

## Notes

- Install planning/execution logic was intentionally left unchanged.
- No changes were made under `OptiClick.Wpf/Install`, `OptiClick.Core`, or `OptiClick.Infrastructure`.
- Local-only ignored tests were updated for validation, but they are not part of the public PR scope.

## Validation

- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln`

Both passed after each refactor stage.