### PR TITLE
[codex] Split shell section factory inputs

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -251,57 +251,74 @@ public sealed partial class MainViewModel : ViewModelBase
         var sections = new ShellSectionsFactory().Create(
             new ShellSectionsFactoryInput
             {
-                StringsAccessor = () => Strings,
-                Games = games,
-                SelectGameAsync = (game, cancellationToken) => SelectGameCardAsync(game, cancellationToken),
-                ShowDetails = ShowDetailsDialog,
-                ShowInstallAsync = ShowInstallDialogAsync,
-                CanSelectGame = () => !_isInstallExecutionInProgress && !_isAppUpdateInProgress,
-                CanShowDetails = () => SelectedGame is not null,
-                CanShowInstall = () => SelectedGame is not null
-                                      && !_isInstallExecutionInProgress
-                                      && !_isAppUpdateInProgress
-                                      && !ShouldBlockStartupForUnsupportedOperatingSystem(),
-                OnSelectGameException = ex => LogError(MainViewModelLogCategories.Command, "select game command failed", ex),
-                OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex),
-                DefaultFolders = defaultFolders,
-                AddedFolders = addedFolders,
-                ScanFolderListController = scanFolderListController,
-                ScanFolderActionController = scanFolderActionController,
-                ApplyScanFolderActionResult = result => ApplyDeferredStateUpdate(
-                    _resultApplier.CreateScanFolderActionStateUpdate(result)),
-                ScanFlowController = scanFlowController,
-                ScanLock = _scanLock,
-                ScannedGameState = _scannedGameState,
-                DialogPresenter = _dialogPresenter,
-                IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
-                BuildScanRequest = BuildScanRequest,
-                ApplyScanFlowResultAsync = ApplyScanFlowResultAsync,
-                RunWithStartupAutoSelectionSuppressedAsync = RunWithStartupAutoSelectionSuppressedAsync,
-                ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
-                ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
-                ClearVisibleGameCards = () => ReplaceGameCards([]),
-                LogScanWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
-                ShowHome = () => SetCurrentView(ShellViewKind.Home),
-                AddedFolderStatusBrush = AddedFolderStatusBrush,
-                MissingFolderStatusBrush = MissingFolderStatusBrush,
-                OnScanCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex),
-                SupportedGamesWikiMarkdownLoader = supportedGamesWikiMarkdownLoader,
-                StartupBackgroundTaskManager = _startupBackgroundTaskManager,
-                AppLogger = _appLogger,
-                SelectedLanguageAccessor = () => SelectedLanguage,
-                CurrentViewKindAccessor = () => CurrentViewKind,
-                OpenGameSupportRequestCommandAccessor = () => OpenGameSupportRequestCommand,
-                UpdateStartupPreparationState = UpdateStartupPreparationState,
-                LocalDataPathProvider = _localDataPathProvider,
-                IsKoreanUi = () => IsKoreanUi,
-                SettingsLanguageOptions = settingsLanguageOptions,
-                InitialSettingsLanguageOption = LanguageOptionAuto,
-                ApplySettingsLanguageOption = ApplySettingsLanguageOption,
-                IsInstallExecutionInProgress = () => _isInstallExecutionInProgress,
-                OpenLogFolder = OpenLogFolder,
-                OpenSupportRequest = OpenSupportRequest,
-                OnRefreshInstallFilesException = ex => LogError(MainViewModelLogCategories.Command, "reset app cache command failed", ex)
+                Home = new HomeSectionFactoryInput
+                {
+                    StringsAccessor = () => Strings,
+                    Games = games,
+                    SelectGameAsync = (game, cancellationToken) => SelectGameCardAsync(game, cancellationToken),
+                    ShowDetails = ShowDetailsDialog,
+                    ShowInstallAsync = ShowInstallDialogAsync,
+                    CanSelectGame = () => !_isInstallExecutionInProgress && !_isAppUpdateInProgress,
+                    CanShowDetails = () => SelectedGame is not null,
+                    CanShowInstall = () => SelectedGame is not null
+                                          && !_isInstallExecutionInProgress
+                                          && !_isAppUpdateInProgress
+                                          && !ShouldBlockStartupForUnsupportedOperatingSystem(),
+                    OnSelectGameException = ex => LogError(MainViewModelLogCategories.Command, "select game command failed", ex),
+                    OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex)
+                },
+                Scan = new ScanSectionFactoryInput
+                {
+                    StringsAccessor = () => Strings,
+                    DefaultFolders = defaultFolders,
+                    AddedFolders = addedFolders,
+                    ScanFolderListController = scanFolderListController,
+                    ScanFolderActionController = scanFolderActionController,
+                    ApplyScanFolderActionResult = result => ApplyDeferredStateUpdate(
+                        _resultApplier.CreateScanFolderActionStateUpdate(result)),
+                    ScanFlowController = scanFlowController,
+                    ScanLock = _scanLock,
+                    ScannedGameState = _scannedGameState,
+                    DialogPresenter = _dialogPresenter,
+                    IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
+                    BuildScanRequest = BuildScanRequest,
+                    ApplyScanFlowResultAsync = ApplyScanFlowResultAsync,
+                    RunWithStartupAutoSelectionSuppressedAsync = RunWithStartupAutoSelectionSuppressedAsync,
+                    ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
+                    ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
+                    ClearVisibleGameCards = () => ReplaceGameCards([]),
+                    LogScanWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
+                    ShowHome = () => SetCurrentView(ShellViewKind.Home),
+                    AddedFolderStatusBrush = AddedFolderStatusBrush,
+                    MissingFolderStatusBrush = MissingFolderStatusBrush,
+                    OnScanCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex)
+                },
+                SupportedGames = new SupportedGamesSectionFactoryInput
+                {
+                    SupportedGamesWikiMarkdownLoader = supportedGamesWikiMarkdownLoader,
+                    StartupBackgroundTaskManager = _startupBackgroundTaskManager,
+                    AppLogger = _appLogger,
+                    StringsAccessor = () => Strings,
+                    SelectedLanguageAccessor = () => SelectedLanguage,
+                    CurrentViewKindAccessor = () => CurrentViewKind,
+                    OpenGameSupportRequestCommandAccessor = () => OpenGameSupportRequestCommand,
+                    UpdateStartupPreparationState = UpdateStartupPreparationState
+                },
+                Settings = new SettingsSectionFactoryInput
+                {
+                    StringsAccessor = () => Strings,
+                    DialogPresenter = _dialogPresenter,
+                    LocalDataPathProvider = _localDataPathProvider,
+                    AppLogger = _appLogger,
+                    IsKoreanUi = () => IsKoreanUi,
+                    SettingsLanguageOptions = settingsLanguageOptions,
+                    InitialSettingsLanguageOption = LanguageOptionAuto,
+                    ApplySettingsLanguageOption = ApplySettingsLanguageOption,
+                    IsInstallExecutionInProgress = () => _isInstallExecutionInProgress,
+                    OpenLogFolder = OpenLogFolder,
+                    OpenSupportRequest = OpenSupportRequest,
+                    OnRefreshInstallFilesException = ex => LogError(MainViewModelLogCategories.Command, "reset app cache command failed", ex)
+                }
             });
 
         Home = sections.Home;

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
@@ -29,13 +29,13 @@ public sealed class ShellSectionsFactory
         ArgumentNullException.ThrowIfNull(input);
 
         return new ShellSections(
-            CreateHome(input),
-            CreateScan(input),
-            CreateSupportedGames(input),
-            CreateSettings(input));
+            CreateHome(input.Home),
+            CreateScan(input.Scan),
+            CreateSupportedGames(input.SupportedGames),
+            CreateSettings(input.Settings));
     }
 
-    private static HomeSectionViewModel CreateHome(ShellSectionsFactoryInput input)
+    private static HomeSectionViewModel CreateHome(HomeSectionFactoryInput input)
     {
         return new HomeSectionViewModel(
             new HomeSectionViewModelOptions
@@ -54,7 +54,7 @@ public sealed class ShellSectionsFactory
             });
     }
 
-    private static ScanSectionViewModel CreateScan(ShellSectionsFactoryInput input)
+    private static ScanSectionViewModel CreateScan(ScanSectionFactoryInput input)
     {
         return new ScanSectionViewModel(
             new ScanSectionViewModelOptions
@@ -84,7 +84,7 @@ public sealed class ShellSectionsFactory
             });
     }
 
-    private static SupportedGamesSectionViewModel CreateSupportedGames(ShellSectionsFactoryInput input)
+    private static SupportedGamesSectionViewModel CreateSupportedGames(SupportedGamesSectionFactoryInput input)
     {
         return new SupportedGamesSectionViewModel(
             input.SupportedGamesWikiMarkdownLoader,
@@ -97,7 +97,7 @@ public sealed class ShellSectionsFactory
             input.UpdateStartupPreparationState);
     }
 
-    private static SettingsSectionViewModel CreateSettings(ShellSectionsFactoryInput input)
+    private static SettingsSectionViewModel CreateSettings(SettingsSectionFactoryInput input)
     {
         var settingsActionCoordinator = new SettingsActionCoordinator(
             input.DialogPresenter,
@@ -129,6 +129,14 @@ public sealed record ShellSections(
 
 public sealed record ShellSectionsFactoryInput
 {
+    public required HomeSectionFactoryInput Home { get; init; }
+    public required ScanSectionFactoryInput Scan { get; init; }
+    public required SupportedGamesSectionFactoryInput SupportedGames { get; init; }
+    public required SettingsSectionFactoryInput Settings { get; init; }
+}
+
+public sealed record HomeSectionFactoryInput
+{
     public required Func<AppStrings> StringsAccessor { get; init; }
     public required ObservableCollection<GameCardViewModel> Games { get; init; }
     public required Func<GameCardViewModel, CancellationToken, Task> SelectGameAsync { get; init; }
@@ -139,7 +147,11 @@ public sealed record ShellSectionsFactoryInput
     public required Func<bool> CanShowInstall { get; init; }
     public Action<Exception>? OnSelectGameException { get; init; }
     public Action<Exception>? OnShowInstallException { get; init; }
+}
 
+public sealed record ScanSectionFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
     public required ObservableCollection<ScanFolderRowViewModel> DefaultFolders { get; init; }
     public required ObservableCollection<ScanFolderRowViewModel> AddedFolders { get; init; }
     public required ScanFolderListController ScanFolderListController { get; init; }
@@ -161,16 +173,26 @@ public sealed record ShellSectionsFactoryInput
     public required Brush AddedFolderStatusBrush { get; init; }
     public required Brush MissingFolderStatusBrush { get; init; }
     public Action<Exception>? OnScanCommandException { get; init; }
+}
 
+public sealed record SupportedGamesSectionFactoryInput
+{
     public required ISupportedGamesWikiMarkdownLoader SupportedGamesWikiMarkdownLoader { get; init; }
     public required StartupBackgroundTaskManager StartupBackgroundTaskManager { get; init; }
     public required IAppLogger AppLogger { get; init; }
+    public required Func<AppStrings> StringsAccessor { get; init; }
     public required Func<AppLanguage> SelectedLanguageAccessor { get; init; }
     public required Func<ShellViewKind> CurrentViewKindAccessor { get; init; }
     public required Func<ICommand> OpenGameSupportRequestCommandAccessor { get; init; }
     public required Action<Func<StartupPreparationState, StartupPreparationState>> UpdateStartupPreparationState { get; init; }
+}
 
+public sealed record SettingsSectionFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
     public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
+    public required IAppLogger AppLogger { get; init; }
     public required Func<bool> IsKoreanUi { get; init; }
     public required ObservableCollection<string> SettingsLanguageOptions { get; init; }
     public required string InitialSettingsLanguageOption { get; init; }


### PR DESCRIPTION
## Summary
- Split the broad `ShellSectionsFactoryInput` into section-specific inputs for Home, Scan, Supported Games, and Settings.
- Reorganized `MainViewModel` section creation wiring so each section receives its own input group.
- Kept existing callbacks and shell behavior unchanged.

## Install Logic
- No install logic changes.
- No changes under `OptiClick.Core`, `OptiClick.Infrastructure`, or `OptiClick.Wpf/Install`.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check` (no whitespace errors; only existing LF/CRLF notices)