### PR TITLE
[codex] Guard shell section factory inputs

### DIFF
--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
@@ -27,6 +27,10 @@ public sealed class ShellSectionsFactory
     public ShellSections Create(ShellSectionsFactoryInput input)
     {
         ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.Home);
+        ArgumentNullException.ThrowIfNull(input.Scan);
+        ArgumentNullException.ThrowIfNull(input.SupportedGames);
+        ArgumentNullException.ThrowIfNull(input.Settings);
 
         return new ShellSections(
             CreateHome(input.Home),


### PR DESCRIPTION
## Summary
- Add explicit null guards for the section-specific inputs passed to `ShellSectionsFactory.Create()`.
- Keeps the PR #15 structure intact while reflecting the small review suggestion.

## Install Logic
- No install logic changes.
- No changes under `OptiClick.Core`, `OptiClick.Infrastructure`, or `OptiClick.Wpf/Install`.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- `dotnet build .\OptiClick.sln -c Release` after rebasing onto latest `main`
- `git diff --check` (no whitespace errors; only existing LF/CRLF notices)