### PR TITLE
[codex] Extract scan orchestrator

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -248,6 +248,23 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
+        var scanOrchestrator = new ScanOrchestrator(
+            new ScanOrchestratorOptions
+            {
+                StringsAccessor = () => Strings,
+                ScanFlowController = scanFlowController,
+                ScanLock = _scanLock,
+                ScannedGameState = _scannedGameState,
+                DialogPresenter = _dialogPresenter,
+                IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
+                BuildScanRequest = BuildScanRequest,
+                ApplyScanFlowResultAsync = ApplyScanFlowResultAsync,
+                RunWithStartupAutoSelectionSuppressedAsync = RunWithStartupAutoSelectionSuppressedAsync,
+                ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
+                ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
+                ClearVisibleGameCards = () => ReplaceGameCards([]),
+                LogWarning = message => LogWarning(MainViewModelLogCategories.Scan, message)
+            });
         var sections = new ShellSectionsFactory().Create(
             new ShellSectionsFactoryInput
             {
@@ -276,18 +293,7 @@ public sealed partial class MainViewModel : ViewModelBase
                     ScanFolderActionController = scanFolderActionController,
                     ApplyScanFolderActionResult = result => ApplyDeferredStateUpdate(
                         _resultApplier.CreateScanFolderActionStateUpdate(result)),
-                    ScanFlowController = scanFlowController,
-                    ScanLock = _scanLock,
-                    ScannedGameState = _scannedGameState,
-                    DialogPresenter = _dialogPresenter,
-                    IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
-                    BuildScanRequest = BuildScanRequest,
-                    ApplyScanFlowResultAsync = ApplyScanFlowResultAsync,
-                    RunWithStartupAutoSelectionSuppressedAsync = RunWithStartupAutoSelectionSuppressedAsync,
-                    ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
-                    ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
-                    ClearVisibleGameCards = () => ReplaceGameCards([]),
-                    LogScanWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
+                    ScanOrchestrator = scanOrchestrator,
                     ShowHome = () => SetCurrentView(ShellViewKind.Home),
                     AddedFolderStatusBrush = AddedFolderStatusBrush,
                     MissingFolderStatusBrush = MissingFolderStatusBrush,

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
@@ -1,0 +1,158 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Models;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.Threading;
+
+namespace OptiClick.Wpf.ViewModels.Sections.Scan;
+
+public sealed class ScanOrchestrator
+{
+    private readonly Func<AppStrings> _stringsAccessor;
+    private readonly ScanFlowController _scanFlowController;
+    private readonly SemaphoreSlim _scanLock;
+    private readonly ScannedGameState _scannedGameState;
+    private readonly DialogPresenter _dialogPresenter;
+    private readonly Func<bool> _isMultiGpuBlocked;
+    private readonly Func<IReadOnlyList<string>, ScanFlowRequest> _buildScanRequest;
+    private readonly Func<ScanFlowResult, CancellationToken, bool, Task> _applyScanFlowResultAsync;
+    private readonly Func<Func<CancellationToken, Task>, CancellationToken, Task> _runWithStartupAutoSelectionSuppressedAsync;
+    private readonly Action<ScanFlowResult> _applyStartupNoGamesNavigation;
+    private readonly Func<ScanFlowResult, CancellationToken, Task> _showStartupNoSupportedGamesGuidanceAsync;
+    private readonly Action _clearVisibleGameCards;
+    private readonly Action<string> _logWarning;
+
+    public ScanOrchestrator(ScanOrchestratorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _stringsAccessor = options.StringsAccessor ?? throw new ArgumentNullException(nameof(options.StringsAccessor));
+        _scanFlowController = options.ScanFlowController ?? throw new ArgumentNullException(nameof(options.ScanFlowController));
+        _scanLock = options.ScanLock ?? throw new ArgumentNullException(nameof(options.ScanLock));
+        _scannedGameState = options.ScannedGameState ?? throw new ArgumentNullException(nameof(options.ScannedGameState));
+        _dialogPresenter = options.DialogPresenter ?? throw new ArgumentNullException(nameof(options.DialogPresenter));
+        _isMultiGpuBlocked = options.IsMultiGpuBlocked ?? throw new ArgumentNullException(nameof(options.IsMultiGpuBlocked));
+        _buildScanRequest = options.BuildScanRequest ?? throw new ArgumentNullException(nameof(options.BuildScanRequest));
+        _applyScanFlowResultAsync = options.ApplyScanFlowResultAsync ?? throw new ArgumentNullException(nameof(options.ApplyScanFlowResultAsync));
+        _runWithStartupAutoSelectionSuppressedAsync = options.RunWithStartupAutoSelectionSuppressedAsync ?? throw new ArgumentNullException(nameof(options.RunWithStartupAutoSelectionSuppressedAsync));
+        _applyStartupNoGamesNavigation = options.ApplyStartupNoGamesNavigation ?? throw new ArgumentNullException(nameof(options.ApplyStartupNoGamesNavigation));
+        _showStartupNoSupportedGamesGuidanceAsync = options.ShowStartupNoSupportedGamesGuidanceAsync ?? throw new ArgumentNullException(nameof(options.ShowStartupNoSupportedGamesGuidanceAsync));
+        _clearVisibleGameCards = options.ClearVisibleGameCards ?? throw new ArgumentNullException(nameof(options.ClearVisibleGameCards));
+        _logWarning = options.LogWarning ?? throw new ArgumentNullException(nameof(options.LogWarning));
+    }
+
+    public async Task SaveAndStartScanAsync(
+        ScanOrchestratorContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var strings = _stringsAccessor();
+        if (_isMultiGpuBlocked())
+        {
+            context.SetScanStatusText(strings.ScanBlockedUnsupportedGpuConfiguration);
+            await _dialogPresenter.ShowSafelyAsync(
+                new AppDialogRequest
+                {
+                    Kind = AppDialogKind.Warning,
+                    Severity = DialogSeverity.Warning,
+                    Title = strings.GpuUnsupportedConfigurationTitle,
+                    Summary = strings.ScanBlockedUnsupportedGpuConfiguration
+                },
+                cancellationToken);
+            return;
+        }
+
+        context.SaveScanFoldersToManifest();
+        if (!context.HasAnyEnabledScanFolders())
+        {
+            _scannedGameState.Clear();
+            _clearVisibleGameCards();
+            context.SetScanStatusText(strings.ScanNoFolderSelected);
+            await _dialogPresenter.ShowSafelyAsync(
+                new AppDialogRequest
+                {
+                    Kind = AppDialogKind.Warning,
+                    Severity = DialogSeverity.Warning,
+                    Title = strings.NavScan,
+                    Summary = strings.ScanNoFolderSelected
+                },
+                cancellationToken);
+            return;
+        }
+
+        await _scanLock.TryRunExclusiveAsync(
+            async ct =>
+            {
+                context.SetScanStatusText(_stringsAccessor().ScanInProgress);
+                var result = await _scanFlowController.RunManualScanAsync(
+                    _buildScanRequest(context.ResolveScanFolders()),
+                    ct);
+                await _applyScanFlowResultAsync(result, ct, true);
+            },
+            cancellationToken);
+    }
+
+    public async Task RunStartupAutoScanAsync(
+        ScanOrchestratorContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var strings = _stringsAccessor();
+        if (_isMultiGpuBlocked())
+        {
+            context.SetScanStatusText(strings.ScanBlockedUnsupportedGpuConfiguration);
+            _logWarning("startup auto scan skipped reason=multi_gpu_blocked");
+            return;
+        }
+
+        var ran = await _scanLock.TryRunExclusiveAsync(
+            async ct =>
+            {
+                await _runWithStartupAutoSelectionSuppressedAsync(
+                    async innerCt =>
+                    {
+                        var result = await _scanFlowController.RunStartupAutoScanAsync(
+                            _buildScanRequest(context.ResolveScanFolders()),
+                            innerCt);
+                        await _applyScanFlowResultAsync(result, innerCt, false);
+                        _applyStartupNoGamesNavigation(result);
+                        await _showStartupNoSupportedGamesGuidanceAsync(result, innerCt);
+                    },
+                    ct);
+            },
+            cancellationToken);
+        if (!ran)
+        {
+            _logWarning("startup auto scan skipped reason=scan_lock_busy");
+        }
+    }
+}
+
+public sealed record ScanOrchestratorOptions
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required ScanFlowController ScanFlowController { get; init; }
+    public required SemaphoreSlim ScanLock { get; init; }
+    public required ScannedGameState ScannedGameState { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required Func<bool> IsMultiGpuBlocked { get; init; }
+    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
+    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
+    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
+    public required Action ClearVisibleGameCards { get; init; }
+    public required Action<string> LogWarning { get; init; }
+}
+
+public sealed record ScanOrchestratorContext
+{
+    public required Action SaveScanFoldersToManifest { get; init; }
+    public required Func<bool> HasAnyEnabledScanFolders { get; init; }
+    public required Func<IReadOnlyList<string>> ResolveScanFolders { get; init; }
+    public required Action<string> SetScanStatusText { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanSectionViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanSectionViewModel.cs
@@ -7,9 +7,7 @@ using System.Windows;
 using System.Windows.Media;
 using OptiClick.Wpf.Models;
 using OptiClick.Wpf.Localization;
-using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Scan;
-using OptiClick.Wpf.Threading;
 
 namespace OptiClick.Wpf.ViewModels.Sections.Scan;
 
@@ -19,18 +17,7 @@ public sealed class ScanSectionViewModel : ViewModelBase
     private readonly ScanFolderListController _scanFolderListController;
     private readonly ScanFolderActionController _scanFolderActionController;
     private readonly Action<ScanFolderActionResult> _applyScanFolderActionResult;
-    private readonly ScanFlowController _scanFlowController;
-    private readonly SemaphoreSlim _scanLock;
-    private readonly ScannedGameState _scannedGameState;
-    private readonly DialogPresenter _dialogPresenter;
-    private readonly Func<bool> _isMultiGpuBlocked;
-    private readonly Func<IReadOnlyList<string>, ScanFlowRequest> _buildScanRequest;
-    private readonly Func<ScanFlowResult, CancellationToken, bool, Task> _applyScanFlowResultAsync;
-    private readonly Func<Func<CancellationToken, Task>, CancellationToken, Task> _runWithStartupAutoSelectionSuppressedAsync;
-    private readonly Action<ScanFlowResult> _applyStartupNoGamesNavigation;
-    private readonly Func<ScanFlowResult, CancellationToken, Task> _showStartupNoSupportedGamesGuidanceAsync;
-    private readonly Action _clearVisibleGameCards;
-    private readonly Action<string> _logWarning;
+    private readonly ScanOrchestrator _scanOrchestrator;
     private readonly Action _showHome;
     private readonly Brush _addedFolderStatusBrush;
     private readonly Brush _missingFolderStatusBrush;
@@ -44,18 +31,7 @@ public sealed class ScanSectionViewModel : ViewModelBase
         _scanFolderListController = options.ScanFolderListController ?? throw new ArgumentNullException(nameof(options.ScanFolderListController));
         _scanFolderActionController = options.ScanFolderActionController ?? throw new ArgumentNullException(nameof(options.ScanFolderActionController));
         _applyScanFolderActionResult = options.ApplyScanFolderActionResult ?? throw new ArgumentNullException(nameof(options.ApplyScanFolderActionResult));
-        _scanFlowController = options.ScanFlowController ?? throw new ArgumentNullException(nameof(options.ScanFlowController));
-        _scanLock = options.ScanLock ?? throw new ArgumentNullException(nameof(options.ScanLock));
-        _scannedGameState = options.ScannedGameState ?? throw new ArgumentNullException(nameof(options.ScannedGameState));
-        _dialogPresenter = options.DialogPresenter ?? throw new ArgumentNullException(nameof(options.DialogPresenter));
-        _isMultiGpuBlocked = options.IsMultiGpuBlocked ?? throw new ArgumentNullException(nameof(options.IsMultiGpuBlocked));
-        _buildScanRequest = options.BuildScanRequest ?? throw new ArgumentNullException(nameof(options.BuildScanRequest));
-        _applyScanFlowResultAsync = options.ApplyScanFlowResultAsync ?? throw new ArgumentNullException(nameof(options.ApplyScanFlowResultAsync));
-        _runWithStartupAutoSelectionSuppressedAsync = options.RunWithStartupAutoSelectionSuppressedAsync ?? throw new ArgumentNullException(nameof(options.RunWithStartupAutoSelectionSuppressedAsync));
-        _applyStartupNoGamesNavigation = options.ApplyStartupNoGamesNavigation ?? throw new ArgumentNullException(nameof(options.ApplyStartupNoGamesNavigation));
-        _showStartupNoSupportedGamesGuidanceAsync = options.ShowStartupNoSupportedGamesGuidanceAsync ?? throw new ArgumentNullException(nameof(options.ShowStartupNoSupportedGamesGuidanceAsync));
-        _clearVisibleGameCards = options.ClearVisibleGameCards ?? throw new ArgumentNullException(nameof(options.ClearVisibleGameCards));
-        _logWarning = options.LogWarning ?? throw new ArgumentNullException(nameof(options.LogWarning));
+        _scanOrchestrator = options.ScanOrchestrator ?? throw new ArgumentNullException(nameof(options.ScanOrchestrator));
         _showHome = options.ShowHome ?? throw new ArgumentNullException(nameof(options.ShowHome));
         _addedFolderStatusBrush = options.AddedFolderStatusBrush ?? throw new ArgumentNullException(nameof(options.AddedFolderStatusBrush));
         _missingFolderStatusBrush = options.MissingFolderStatusBrush ?? throw new ArgumentNullException(nameof(options.MissingFolderStatusBrush));
@@ -124,82 +100,14 @@ public sealed class ScanSectionViewModel : ViewModelBase
         _scanFolderListController.SaveFoldersToManifest(DefaultFolders, AddedFolders);
     }
 
-    public async Task SaveAndStartScanAsync(CancellationToken cancellationToken = default)
+    public Task SaveAndStartScanAsync(CancellationToken cancellationToken = default)
     {
-        if (_isMultiGpuBlocked())
-        {
-            ScanStatusText = Strings.ScanBlockedUnsupportedGpuConfiguration;
-            await _dialogPresenter.ShowSafelyAsync(
-                new AppDialogRequest
-                {
-                    Kind = AppDialogKind.Warning,
-                    Severity = DialogSeverity.Warning,
-                    Title = Strings.GpuUnsupportedConfigurationTitle,
-                    Summary = Strings.ScanBlockedUnsupportedGpuConfiguration
-                },
-                cancellationToken);
-            return;
-        }
-
-        SaveScanFoldersToManifest();
-        if (!HasAnyEnabledScanFolders())
-        {
-            _scannedGameState.Clear();
-            _clearVisibleGameCards();
-            ScanStatusText = Strings.ScanNoFolderSelected;
-            await _dialogPresenter.ShowSafelyAsync(
-                new AppDialogRequest
-                {
-                    Kind = AppDialogKind.Warning,
-                    Severity = DialogSeverity.Warning,
-                    Title = Strings.NavScan,
-                    Summary = Strings.ScanNoFolderSelected
-                },
-                cancellationToken);
-            return;
-        }
-
-        await _scanLock.TryRunExclusiveAsync(
-            async ct =>
-            {
-                ScanStatusText = Strings.ScanInProgress;
-                var result = await _scanFlowController.RunManualScanAsync(
-                    _buildScanRequest(ResolveScanFolders()),
-                    ct);
-                await _applyScanFlowResultAsync(result, ct, true);
-            },
-            cancellationToken);
+        return _scanOrchestrator.SaveAndStartScanAsync(CreateScanOrchestratorContext(), cancellationToken);
     }
 
-    public async Task RunStartupAutoScanAsync(CancellationToken cancellationToken = default)
+    public Task RunStartupAutoScanAsync(CancellationToken cancellationToken = default)
     {
-        if (_isMultiGpuBlocked())
-        {
-            ScanStatusText = Strings.ScanBlockedUnsupportedGpuConfiguration;
-            _logWarning("startup auto scan skipped reason=multi_gpu_blocked");
-            return;
-        }
-
-        var ran = await _scanLock.TryRunExclusiveAsync(
-            async ct =>
-            {
-                await _runWithStartupAutoSelectionSuppressedAsync(
-                    async innerCt =>
-                    {
-                        var result = await _scanFlowController.RunStartupAutoScanAsync(
-                            _buildScanRequest(ResolveScanFolders()),
-                            innerCt);
-                        await _applyScanFlowResultAsync(result, innerCt, false);
-                        _applyStartupNoGamesNavigation(result);
-                        await _showStartupNoSupportedGamesGuidanceAsync(result, innerCt);
-                    },
-                    ct);
-            },
-            cancellationToken);
-        if (!ran)
-        {
-            _logWarning("startup auto scan skipped reason=scan_lock_busy");
-        }
+        return _scanOrchestrator.RunStartupAutoScanAsync(CreateScanOrchestratorContext(), cancellationToken);
     }
 
     public void ApplyScanFolderStateUpdate(ScanFolderStateUpdate update)
@@ -261,6 +169,17 @@ public sealed class ScanSectionViewModel : ViewModelBase
     {
         ArgumentNullException.ThrowIfNull(result);
         _applyScanFolderActionResult(result);
+    }
+
+    private ScanOrchestratorContext CreateScanOrchestratorContext()
+    {
+        return new ScanOrchestratorContext
+        {
+            SaveScanFoldersToManifest = SaveScanFoldersToManifest,
+            HasAnyEnabledScanFolders = HasAnyEnabledScanFolders,
+            ResolveScanFolders = () => ResolveScanFolders(),
+            SetScanStatusText = value => ScanStatusText = value
+        };
     }
 
     private void OnScanFoldersCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -332,18 +251,7 @@ public sealed record ScanSectionViewModelOptions
     public required ScanFolderListController ScanFolderListController { get; init; }
     public required ScanFolderActionController ScanFolderActionController { get; init; }
     public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
-    public required ScanFlowController ScanFlowController { get; init; }
-    public required SemaphoreSlim ScanLock { get; init; }
-    public required ScannedGameState ScannedGameState { get; init; }
-    public required DialogPresenter DialogPresenter { get; init; }
-    public required Func<bool> IsMultiGpuBlocked { get; init; }
-    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
-    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
-    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
-    public required Action ClearVisibleGameCards { get; init; }
-    public required Action<string> LogWarning { get; init; }
+    public required ScanOrchestrator ScanOrchestrator { get; init; }
     public required Action ShowHome { get; init; }
     public required Brush AddedFolderStatusBrush { get; init; }
     public required Brush MissingFolderStatusBrush { get; init; }

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
@@ -69,18 +69,7 @@ public sealed class ShellSectionsFactory
                 ScanFolderListController = input.ScanFolderListController,
                 ScanFolderActionController = input.ScanFolderActionController,
                 ApplyScanFolderActionResult = input.ApplyScanFolderActionResult,
-                ScanFlowController = input.ScanFlowController,
-                ScanLock = input.ScanLock,
-                ScannedGameState = input.ScannedGameState,
-                DialogPresenter = input.DialogPresenter,
-                IsMultiGpuBlocked = input.IsMultiGpuBlocked,
-                BuildScanRequest = input.BuildScanRequest,
-                ApplyScanFlowResultAsync = input.ApplyScanFlowResultAsync,
-                RunWithStartupAutoSelectionSuppressedAsync = input.RunWithStartupAutoSelectionSuppressedAsync,
-                ApplyStartupNoGamesNavigation = input.ApplyStartupNoGamesNavigation,
-                ShowStartupNoSupportedGamesGuidanceAsync = input.ShowStartupNoSupportedGamesGuidanceAsync,
-                ClearVisibleGameCards = input.ClearVisibleGameCards,
-                LogWarning = input.LogScanWarning,
+                ScanOrchestrator = input.ScanOrchestrator,
                 ShowHome = input.ShowHome,
                 AddedFolderStatusBrush = input.AddedFolderStatusBrush,
                 MissingFolderStatusBrush = input.MissingFolderStatusBrush,
@@ -161,18 +150,7 @@ public sealed record ScanSectionFactoryInput
     public required ScanFolderListController ScanFolderListController { get; init; }
     public required ScanFolderActionController ScanFolderActionController { get; init; }
     public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
-    public required ScanFlowController ScanFlowController { get; init; }
-    public required SemaphoreSlim ScanLock { get; init; }
-    public required ScannedGameState ScannedGameState { get; init; }
-    public required DialogPresenter DialogPresenter { get; init; }
-    public required Func<bool> IsMultiGpuBlocked { get; init; }
-    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
-    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
-    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
-    public required Action ClearVisibleGameCards { get; init; }
-    public required Action<string> LogScanWarning { get; init; }
+    public required ScanOrchestrator ScanOrchestrator { get; init; }
     public required Action ShowHome { get; init; }
     public required Brush AddedFolderStatusBrush { get; init; }
     public required Brush MissingFolderStatusBrush { get; init; }


### PR DESCRIPTION
## Summary
- Added `ScanOrchestrator` to own manual scan and startup auto-scan execution flow.
- Reduced `ScanSectionViewModel` so it keeps scan folder UI state, commands, localization refresh, and folder row handling while delegating scan execution.
- Slimmed `ScanSectionFactoryInput` and `ScanSectionViewModelOptions` by replacing the scan execution callback bundle with a single orchestrator dependency.

## Install Logic
- No install logic changes.
- No changes under `OptiClick.Core`, `OptiClick.Infrastructure`, or `OptiClick.Wpf/Install`.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check` (no whitespace errors; only existing LF/CRLF notices)