### PR TITLE
[codex] Add scan orchestrator factory

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -248,8 +248,8 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
-        var scanOrchestrator = new ScanOrchestrator(
-            new ScanOrchestratorOptions
+        var scanOrchestrator = new ScanOrchestratorFactory().Create(
+            new ScanOrchestratorFactoryInput
             {
                 StringsAccessor = () => Strings,
                 ScanFlowController = scanFlowController,

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
@@ -24,7 +24,7 @@ public sealed class ScanOrchestrator
     private readonly Action _clearVisibleGameCards;
     private readonly Action<string> _logWarning;
 
-    public ScanOrchestrator(ScanOrchestratorOptions options)
+    internal ScanOrchestrator(ScanOrchestratorOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -132,7 +132,7 @@ public sealed class ScanOrchestrator
     }
 }
 
-public sealed record ScanOrchestratorOptions
+internal sealed record ScanOrchestratorOptions
 {
     public required Func<AppStrings> StringsAccessor { get; init; }
     public required ScanFlowController ScanFlowController { get; init; }

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestratorFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestratorFactory.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Scan;
+
+namespace OptiClick.Wpf.ViewModels.Sections.Scan;
+
+public sealed class ScanOrchestratorFactory
+{
+    public ScanOrchestrator Create(ScanOrchestratorFactoryInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new ScanOrchestrator(
+            new ScanOrchestratorOptions
+            {
+                StringsAccessor = input.StringsAccessor,
+                ScanFlowController = input.ScanFlowController,
+                ScanLock = input.ScanLock,
+                ScannedGameState = input.ScannedGameState,
+                DialogPresenter = input.DialogPresenter,
+                IsMultiGpuBlocked = input.IsMultiGpuBlocked,
+                BuildScanRequest = input.BuildScanRequest,
+                ApplyScanFlowResultAsync = input.ApplyScanFlowResultAsync,
+                RunWithStartupAutoSelectionSuppressedAsync = input.RunWithStartupAutoSelectionSuppressedAsync,
+                ApplyStartupNoGamesNavigation = input.ApplyStartupNoGamesNavigation,
+                ShowStartupNoSupportedGamesGuidanceAsync = input.ShowStartupNoSupportedGamesGuidanceAsync,
+                ClearVisibleGameCards = input.ClearVisibleGameCards,
+                LogWarning = input.LogWarning
+            });
+    }
+}
+
+public sealed record ScanOrchestratorFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required ScanFlowController ScanFlowController { get; init; }
+    public required SemaphoreSlim ScanLock { get; init; }
+    public required ScannedGameState ScannedGameState { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required Func<bool> IsMultiGpuBlocked { get; init; }
+    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
+    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
+    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
+    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
+    public required Action ClearVisibleGameCards { get; init; }
+    public required Action<string> LogWarning { get; init; }
+}


### PR DESCRIPTION
## Summary
- Added `ScanOrchestratorFactory` as the public creation path for scan orchestration.
- Moved `MainViewModel` off direct `ScanOrchestrator` construction and direct `ScanOrchestratorOptions` usage.
- Narrowed `ScanOrchestrator` constructor and options visibility to internal so factory creation is the intended path.

## Install Logic
- No install logic changes.
- No changes under `OptiClick.Core`, `OptiClick.Infrastructure`, or `OptiClick.Wpf/Install`.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check` (no whitespace errors; only existing LF/CRLF notices)