### PR TITLE
[codex] Inject scan orchestrator factory

### DIFF
--- a/OptiClick.Wpf/Composition/MainWindowComposition.cs
+++ b/OptiClick.Wpf/Composition/MainWindowComposition.cs
@@ -16,6 +16,7 @@ using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
 using System.Net.Http;
 
 namespace OptiClick.Wpf.Composition;
@@ -50,6 +51,7 @@ public sealed class MainWindowComposition
             scanFolderListController,
             scan.FolderPickerService,
             scanFolderDialogPresenter);
+        var scanOrchestratorFactory = new ScanOrchestratorFactory();
         var startupNoticePresenter = new StartupNoticePresenter();
         var gameMasterCoverPrefetchService = new GameMasterCoverPrefetchService();
         var shellCommandActionController = new ShellCommandActionController(
@@ -126,7 +128,8 @@ public sealed class MainWindowComposition
                 ScanFlowController = scan.ScanFlowController,
                 ScanFolderListController = scanFolderListController,
                 ScanFolderDialogPresenter = scanFolderDialogPresenter,
-                ScanFolderActionController = scanFolderActionController
+                ScanFolderActionController = scanFolderActionController,
+                ScanOrchestratorFactory = scanOrchestratorFactory
             },
             Install = new MainViewModelInstallDependencies
             {

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -190,6 +190,7 @@ public sealed partial class MainViewModel : ViewModelBase
         _userSettingsController = resolved.UserSettingsController;
         var scanFolderListController = resolved.ScanFolderListController;
         var scanFolderActionController = resolved.ScanFolderActionController;
+        var scanOrchestratorFactory = resolved.ScanOrchestratorFactory;
         _scanVisibleGameResolver = resolved.ScanVisibleGameResolver;
         _installPopupPresenter = resolved.InstallPopupPresenter;
         _archiveReadinessFlowController = resolved.ArchiveReadinessFlowController;
@@ -248,7 +249,7 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
-        var scanOrchestrator = new ScanOrchestratorFactory().Create(
+        var scanOrchestrator = scanOrchestratorFactory.Create(
             new ScanOrchestratorFactoryInput
             {
                 StringsAccessor = () => Strings,

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
@@ -27,6 +27,7 @@ using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
 using OptiClick.Infrastructure.FileSystem;
 
 namespace OptiClick.Wpf.ViewModels;
@@ -65,6 +66,7 @@ public sealed record MainViewModelScanDependencies
     public ScanFolderListController? ScanFolderListController { get; init; }
     public ScanFolderDialogPresenter? ScanFolderDialogPresenter { get; init; }
     public ScanFolderActionController? ScanFolderActionController { get; init; }
+    public ScanOrchestratorFactory? ScanOrchestratorFactory { get; init; }
 }
 
 public sealed record MainViewModelInstallDependencies

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
@@ -25,6 +25,7 @@ using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
 using OptiClick.Infrastructure.FileSystem;
 using System.Net.Http;
 
@@ -118,6 +119,7 @@ public static class MainViewModelDependencyResolver
                                              scanFolderListController,
                                              scanDependencies.FolderPickerService,
                                              scanFolderDialogPresenter);
+        var scanOrchestratorFactory = scanDependencies.ScanOrchestratorFactory ?? new ScanOrchestratorFactory();
         var supportIssueContextBuilder = appDependencies.SupportIssueContextBuilder ?? new SupportIssueContextBuilder();
 
         var resolvedInstallPlanInputBuilder = installDependencies.InstallPlanInputBuilder ?? new InstallPlanInputBuilder();
@@ -249,6 +251,7 @@ public static class MainViewModelDependencyResolver
             BusyStateApplier = busyStateApplier,
             ScanFolderDialogPresenter = scanFolderDialogPresenter,
             ScanFolderActionController = scanFolderActionController,
+            ScanOrchestratorFactory = scanOrchestratorFactory,
             SupportActionController = supportActionController,
             SupportIssueContextBuilder = supportIssueContextBuilder,
             InstallPopupPresenter = installPopupPresenter,
@@ -298,6 +301,7 @@ public static class MainViewModelDependencyResolver
         EnsureExplicitDependency(scanDependencies.ScanFlowController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFlowController)}");
         EnsureExplicitDependency(scanDependencies.ScanFolderListController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFolderListController)}");
         EnsureExplicitDependency(scanDependencies.ScanFolderActionController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFolderActionController)}");
+        EnsureExplicitDependency(scanDependencies.ScanOrchestratorFactory, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanOrchestratorFactory)}");
 
         EnsureExplicitDependency(installDependencies.ArchiveReadinessFlowController, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.ArchiveReadinessFlowController)}");
         EnsureExplicitDependency(installDependencies.InstallFlowController, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.InstallFlowController)}");

--- a/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
@@ -22,6 +22,7 @@ using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
 using OptiClick.Infrastructure.FileSystem;
 
 namespace OptiClick.Wpf.ViewModels;
@@ -75,6 +76,7 @@ public sealed record MainViewModelResolvedDependencies
     public required MainViewModelBusyStateApplier BusyStateApplier { get; init; }
     public required ScanFolderDialogPresenter ScanFolderDialogPresenter { get; init; }
     public required ScanFolderActionController ScanFolderActionController { get; init; }
+    public required ScanOrchestratorFactory ScanOrchestratorFactory { get; init; }
     public required SupportActionController SupportActionController { get; init; }
     public required SupportIssueContextBuilder SupportIssueContextBuilder { get; init; }
     public required InstallPopupPresenter InstallPopupPresenter { get; init; }


### PR DESCRIPTION
## Summary
- Added `ScanOrchestratorFactory` to the `MainViewModel` scan dependency path.
- Wired the factory explicitly from `MainWindowComposition` with fallback resolver support.
- Removed direct `new ScanOrchestratorFactory()` construction from `MainViewModel`.

## Install Logic
- No install logic changes.
- No changes under `OptiClick.Core`, `OptiClick.Infrastructure`, or `OptiClick.Wpf/Install`.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check` (no whitespace errors; only existing LF/CRLF notices)