### PR TITLE
[codex] Extract scan result coordinator

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.SelectionScan.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.SelectionScan.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using OptiClick.Wpf.Services;
 using OptiClick.Wpf.Install.UiState;
-using OptiClick.Wpf.Models;
 using OptiClick.Wpf.Shell.Navigation;
 using OptiClick.Wpf.Shell.Scan;
 using OptiClick.Wpf.Shell.Selection;
@@ -217,102 +216,6 @@ public sealed partial class MainViewModel : ViewModelBase
             _scannedGameState.TargetPathByGameId,
             _runtimeShellState.ModuleDownloadLinks,
             _runtimeShellState.LatestRemoteCatalogErrorCode);
-    }
-
-    private async Task RunWithStartupAutoSelectionSuppressedAsync(
-        Func<CancellationToken, Task> operation,
-        CancellationToken cancellationToken)
-    {
-        var previousSuppressFlag = _suppressHomeNavigationForAutoSelection;
-        _suppressHomeNavigationForAutoSelection = true;
-        try
-        {
-            await operation(cancellationToken);
-        }
-        finally
-        {
-            _suppressHomeNavigationForAutoSelection = previousSuppressFlag;
-        }
-    }
-
-    private void ApplyStartupNoGamesNavigation(ScanFlowResult result)
-    {
-        if (!ShouldNavigateToScanForStartupNoGames(result))
-        {
-            return;
-        }
-
-        SetCurrentView(ShellViewKind.Scan);
-    }
-
-    private async Task ShowStartupNoSupportedGamesGuidanceAsync(
-        ScanFlowResult result,
-        CancellationToken cancellationToken)
-    {
-        if (!ShouldShowStartupNoSupportedGamesGuidance(result))
-        {
-            return;
-        }
-
-        SetCurrentView(ShellViewKind.Scan);
-        await _dialogPresenter.ShowSafelyAsync(
-            new AppDialogRequest
-            {
-                Kind = AppDialogKind.Warning,
-                Severity = DialogSeverity.Warning,
-                Title = Strings.NavScan,
-                Summary = Strings.ScanNoSupportedGamesFoundGuide
-            },
-            cancellationToken);
-    }
-
-    private bool ShouldNavigateToScanForStartupNoGames(ScanFlowResult result)
-    {
-        if (result.Summary.MatchedCount > 0 || Games.Count > 0)
-        {
-            return false;
-        }
-
-        return string.IsNullOrWhiteSpace(_runtimeShellState.LatestRemoteCatalogErrorCode);
-    }
-
-    private bool ShouldShowStartupNoSupportedGamesGuidance(ScanFlowResult result)
-    {
-        if (!ShouldNavigateToScanForStartupNoGames(result))
-        {
-            return false;
-        }
-
-        if (!result.DidRun)
-        {
-            return false;
-        }
-        return true;
-    }
-
-    private async Task ApplyScanFlowResultAsync(
-        ScanFlowResult result,
-        CancellationToken cancellationToken,
-        bool navigateHome)
-    {
-        _flowLogDispatcher.Dispatch(result.Logs, MainViewModelLogCategories.Scan);
-        var update = _resultApplier.CreateScanStateUpdate(result);
-        ApplyStateUpdate(update);
-
-        if (update.DialogRequest is not null)
-        {
-            await _dialogPresenter.ShowSafelyAsync(update.DialogRequest, cancellationToken);
-        }
-
-        if (update.ShouldRecomputeSelection)
-        {
-            await RecomputeSelectionAfterScanAsync(cancellationToken, navigateHome);
-        }
-
-        if (update.ShouldNavigateHome && Games.Count > 0)
-        {
-            SetCurrentView(ShellViewKind.Home);
-        }
     }
 
     private GameCardViewModel? RefreshVisibleGamesFromScanMatches()

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -249,6 +249,22 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
+        var scanResultCoordinator = new ScanResultCoordinator(
+            new ScanResultCoordinatorOptions
+            {
+                FlowLogDispatcher = _flowLogDispatcher,
+                FlowLogFallbackCategory = MainViewModelLogCategories.Scan,
+                ResultApplier = _resultApplier,
+                DialogPresenter = _dialogPresenter,
+                StringsAccessor = () => Strings,
+                GameCountAccessor = () => Games.Count,
+                RemoteCatalogErrorCodeAccessor = () => _runtimeShellState.LatestRemoteCatalogErrorCode,
+                ReadSuppressHomeNavigationForAutoSelection = () => _suppressHomeNavigationForAutoSelection,
+                SetSuppressHomeNavigationForAutoSelection = value => _suppressHomeNavigationForAutoSelection = value,
+                ApplyStateUpdate = ApplyStateUpdate,
+                SetCurrentView = SetCurrentView,
+                RecomputeSelectionAfterScanAsync = RecomputeSelectionAfterScanAsync
+            });
         var scanOrchestrator = scanOrchestratorFactory.Create(
             new ScanOrchestratorFactoryInput
             {
@@ -259,10 +275,7 @@ public sealed partial class MainViewModel : ViewModelBase
                 DialogPresenter = _dialogPresenter,
                 IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
                 BuildScanRequest = BuildScanRequest,
-                ApplyScanFlowResultAsync = ApplyScanFlowResultAsync,
-                RunWithStartupAutoSelectionSuppressedAsync = RunWithStartupAutoSelectionSuppressedAsync,
-                ApplyStartupNoGamesNavigation = ApplyStartupNoGamesNavigation,
-                ShowStartupNoSupportedGamesGuidanceAsync = ShowStartupNoSupportedGamesGuidanceAsync,
+                ScanResultCoordinator = scanResultCoordinator,
                 ClearVisibleGameCards = () => ReplaceGameCards([]),
                 LogWarning = message => LogWarning(MainViewModelLogCategories.Scan, message)
             });

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestrator.cs
@@ -17,10 +17,7 @@ public sealed class ScanOrchestrator
     private readonly DialogPresenter _dialogPresenter;
     private readonly Func<bool> _isMultiGpuBlocked;
     private readonly Func<IReadOnlyList<string>, ScanFlowRequest> _buildScanRequest;
-    private readonly Func<ScanFlowResult, CancellationToken, bool, Task> _applyScanFlowResultAsync;
-    private readonly Func<Func<CancellationToken, Task>, CancellationToken, Task> _runWithStartupAutoSelectionSuppressedAsync;
-    private readonly Action<ScanFlowResult> _applyStartupNoGamesNavigation;
-    private readonly Func<ScanFlowResult, CancellationToken, Task> _showStartupNoSupportedGamesGuidanceAsync;
+    private readonly ScanResultCoordinator _scanResultCoordinator;
     private readonly Action _clearVisibleGameCards;
     private readonly Action<string> _logWarning;
 
@@ -35,10 +32,7 @@ public sealed class ScanOrchestrator
         _dialogPresenter = options.DialogPresenter ?? throw new ArgumentNullException(nameof(options.DialogPresenter));
         _isMultiGpuBlocked = options.IsMultiGpuBlocked ?? throw new ArgumentNullException(nameof(options.IsMultiGpuBlocked));
         _buildScanRequest = options.BuildScanRequest ?? throw new ArgumentNullException(nameof(options.BuildScanRequest));
-        _applyScanFlowResultAsync = options.ApplyScanFlowResultAsync ?? throw new ArgumentNullException(nameof(options.ApplyScanFlowResultAsync));
-        _runWithStartupAutoSelectionSuppressedAsync = options.RunWithStartupAutoSelectionSuppressedAsync ?? throw new ArgumentNullException(nameof(options.RunWithStartupAutoSelectionSuppressedAsync));
-        _applyStartupNoGamesNavigation = options.ApplyStartupNoGamesNavigation ?? throw new ArgumentNullException(nameof(options.ApplyStartupNoGamesNavigation));
-        _showStartupNoSupportedGamesGuidanceAsync = options.ShowStartupNoSupportedGamesGuidanceAsync ?? throw new ArgumentNullException(nameof(options.ShowStartupNoSupportedGamesGuidanceAsync));
+        _scanResultCoordinator = options.ScanResultCoordinator ?? throw new ArgumentNullException(nameof(options.ScanResultCoordinator));
         _clearVisibleGameCards = options.ClearVisibleGameCards ?? throw new ArgumentNullException(nameof(options.ClearVisibleGameCards));
         _logWarning = options.LogWarning ?? throw new ArgumentNullException(nameof(options.LogWarning));
     }
@@ -90,7 +84,7 @@ public sealed class ScanOrchestrator
                 var result = await _scanFlowController.RunManualScanAsync(
                     _buildScanRequest(context.ResolveScanFolders()),
                     ct);
-                await _applyScanFlowResultAsync(result, ct, true);
+                await _scanResultCoordinator.ApplyManualScanResultAsync(result, ct);
             },
             cancellationToken);
     }
@@ -112,15 +106,13 @@ public sealed class ScanOrchestrator
         var ran = await _scanLock.TryRunExclusiveAsync(
             async ct =>
             {
-                await _runWithStartupAutoSelectionSuppressedAsync(
+                await _scanResultCoordinator.RunWithStartupAutoSelectionSuppressedAsync(
                     async innerCt =>
                     {
                         var result = await _scanFlowController.RunStartupAutoScanAsync(
                             _buildScanRequest(context.ResolveScanFolders()),
                             innerCt);
-                        await _applyScanFlowResultAsync(result, innerCt, false);
-                        _applyStartupNoGamesNavigation(result);
-                        await _showStartupNoSupportedGamesGuidanceAsync(result, innerCt);
+                        await _scanResultCoordinator.ApplyStartupAutoScanResultAsync(result, innerCt);
                     },
                     ct);
             },
@@ -141,10 +133,7 @@ internal sealed record ScanOrchestratorOptions
     public required DialogPresenter DialogPresenter { get; init; }
     public required Func<bool> IsMultiGpuBlocked { get; init; }
     public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
-    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
-    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
+    public required ScanResultCoordinator ScanResultCoordinator { get; init; }
     public required Action ClearVisibleGameCards { get; init; }
     public required Action<string> LogWarning { get; init; }
 }

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestratorFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanOrchestratorFactory.cs
@@ -22,10 +22,7 @@ public sealed class ScanOrchestratorFactory
                 DialogPresenter = input.DialogPresenter,
                 IsMultiGpuBlocked = input.IsMultiGpuBlocked,
                 BuildScanRequest = input.BuildScanRequest,
-                ApplyScanFlowResultAsync = input.ApplyScanFlowResultAsync,
-                RunWithStartupAutoSelectionSuppressedAsync = input.RunWithStartupAutoSelectionSuppressedAsync,
-                ApplyStartupNoGamesNavigation = input.ApplyStartupNoGamesNavigation,
-                ShowStartupNoSupportedGamesGuidanceAsync = input.ShowStartupNoSupportedGamesGuidanceAsync,
+                ScanResultCoordinator = input.ScanResultCoordinator,
                 ClearVisibleGameCards = input.ClearVisibleGameCards,
                 LogWarning = input.LogWarning
             });
@@ -41,10 +38,7 @@ public sealed record ScanOrchestratorFactoryInput
     public required DialogPresenter DialogPresenter { get; init; }
     public required Func<bool> IsMultiGpuBlocked { get; init; }
     public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, bool, Task> ApplyScanFlowResultAsync { get; init; }
-    public required Func<Func<CancellationToken, Task>, CancellationToken, Task> RunWithStartupAutoSelectionSuppressedAsync { get; init; }
-    public required Action<ScanFlowResult> ApplyStartupNoGamesNavigation { get; init; }
-    public required Func<ScanFlowResult, CancellationToken, Task> ShowStartupNoSupportedGamesGuidanceAsync { get; init; }
+    public required ScanResultCoordinator ScanResultCoordinator { get; init; }
     public required Action ClearVisibleGameCards { get; init; }
     public required Action<string> LogWarning { get; init; }
 }

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinator.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinator.cs
@@ -1,0 +1,174 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Models;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Flow;
+using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.ViewModels;
+
+namespace OptiClick.Wpf.ViewModels.Sections.Scan;
+
+public sealed class ScanResultCoordinator
+{
+    private readonly FlowLogDispatcher _flowLogDispatcher;
+    private readonly MainViewModelResultApplier _resultApplier;
+    private readonly DialogPresenter _dialogPresenter;
+    private readonly Func<AppStrings> _stringsAccessor;
+    private readonly Func<int> _gameCountAccessor;
+    private readonly Func<string> _remoteCatalogErrorCodeAccessor;
+    private readonly Func<bool> _readSuppressHomeNavigationForAutoSelection;
+    private readonly Action<bool> _setSuppressHomeNavigationForAutoSelection;
+    private readonly Action<MainViewModelStateUpdate> _applyStateUpdate;
+    private readonly Action<ShellViewKind> _setCurrentView;
+    private readonly Func<CancellationToken, bool, Task> _recomputeSelectionAfterScanAsync;
+    private readonly string _flowLogFallbackCategory;
+
+    public ScanResultCoordinator(ScanResultCoordinatorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _flowLogDispatcher = options.FlowLogDispatcher ?? throw new ArgumentNullException(nameof(options.FlowLogDispatcher));
+        _resultApplier = options.ResultApplier ?? throw new ArgumentNullException(nameof(options.ResultApplier));
+        _dialogPresenter = options.DialogPresenter ?? throw new ArgumentNullException(nameof(options.DialogPresenter));
+        _stringsAccessor = options.StringsAccessor ?? throw new ArgumentNullException(nameof(options.StringsAccessor));
+        _gameCountAccessor = options.GameCountAccessor ?? throw new ArgumentNullException(nameof(options.GameCountAccessor));
+        _remoteCatalogErrorCodeAccessor = options.RemoteCatalogErrorCodeAccessor ?? throw new ArgumentNullException(nameof(options.RemoteCatalogErrorCodeAccessor));
+        _readSuppressHomeNavigationForAutoSelection = options.ReadSuppressHomeNavigationForAutoSelection ?? throw new ArgumentNullException(nameof(options.ReadSuppressHomeNavigationForAutoSelection));
+        _setSuppressHomeNavigationForAutoSelection = options.SetSuppressHomeNavigationForAutoSelection ?? throw new ArgumentNullException(nameof(options.SetSuppressHomeNavigationForAutoSelection));
+        _applyStateUpdate = options.ApplyStateUpdate ?? throw new ArgumentNullException(nameof(options.ApplyStateUpdate));
+        _setCurrentView = options.SetCurrentView ?? throw new ArgumentNullException(nameof(options.SetCurrentView));
+        _recomputeSelectionAfterScanAsync = options.RecomputeSelectionAfterScanAsync ?? throw new ArgumentNullException(nameof(options.RecomputeSelectionAfterScanAsync));
+        _flowLogFallbackCategory = string.IsNullOrWhiteSpace(options.FlowLogFallbackCategory)
+            ? MainViewModelLogCategories.Scan
+            : options.FlowLogFallbackCategory;
+    }
+
+    public Task ApplyManualScanResultAsync(
+        ScanFlowResult result,
+        CancellationToken cancellationToken)
+    {
+        return ApplyScanFlowResultAsync(result, cancellationToken, navigateHome: true);
+    }
+
+    public async Task ApplyStartupAutoScanResultAsync(
+        ScanFlowResult result,
+        CancellationToken cancellationToken)
+    {
+        await ApplyScanFlowResultAsync(result, cancellationToken, navigateHome: false);
+        ApplyStartupNoGamesNavigation(result);
+        await ShowStartupNoSupportedGamesGuidanceAsync(result, cancellationToken);
+    }
+
+    public async Task RunWithStartupAutoSelectionSuppressedAsync(
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var previousSuppressFlag = _readSuppressHomeNavigationForAutoSelection();
+        _setSuppressHomeNavigationForAutoSelection(true);
+        try
+        {
+            await operation(cancellationToken);
+        }
+        finally
+        {
+            _setSuppressHomeNavigationForAutoSelection(previousSuppressFlag);
+        }
+    }
+
+    private async Task ApplyScanFlowResultAsync(
+        ScanFlowResult result,
+        CancellationToken cancellationToken,
+        bool navigateHome)
+    {
+        _flowLogDispatcher.Dispatch(result.Logs, _flowLogFallbackCategory);
+        var update = _resultApplier.CreateScanStateUpdate(result);
+        _applyStateUpdate(update);
+
+        if (update.DialogRequest is not null)
+        {
+            await _dialogPresenter.ShowSafelyAsync(update.DialogRequest, cancellationToken);
+        }
+
+        if (update.ShouldRecomputeSelection)
+        {
+            await _recomputeSelectionAfterScanAsync(cancellationToken, navigateHome);
+        }
+
+        if (update.ShouldNavigateHome && _gameCountAccessor() > 0)
+        {
+            _setCurrentView(ShellViewKind.Home);
+        }
+    }
+
+    private void ApplyStartupNoGamesNavigation(ScanFlowResult result)
+    {
+        if (!ShouldNavigateToScanForStartupNoGames(result))
+        {
+            return;
+        }
+
+        _setCurrentView(ShellViewKind.Scan);
+    }
+
+    private async Task ShowStartupNoSupportedGamesGuidanceAsync(
+        ScanFlowResult result,
+        CancellationToken cancellationToken)
+    {
+        if (!ShouldShowStartupNoSupportedGamesGuidance(result))
+        {
+            return;
+        }
+
+        _setCurrentView(ShellViewKind.Scan);
+        var strings = _stringsAccessor();
+        await _dialogPresenter.ShowSafelyAsync(
+            new AppDialogRequest
+            {
+                Kind = AppDialogKind.Warning,
+                Severity = DialogSeverity.Warning,
+                Title = strings.NavScan,
+                Summary = strings.ScanNoSupportedGamesFoundGuide
+            },
+            cancellationToken);
+    }
+
+    private bool ShouldNavigateToScanForStartupNoGames(ScanFlowResult result)
+    {
+        if (result.Summary.MatchedCount > 0 || _gameCountAccessor() > 0)
+        {
+            return false;
+        }
+
+        return string.IsNullOrWhiteSpace(_remoteCatalogErrorCodeAccessor());
+    }
+
+    private bool ShouldShowStartupNoSupportedGamesGuidance(ScanFlowResult result)
+    {
+        if (!ShouldNavigateToScanForStartupNoGames(result))
+        {
+            return false;
+        }
+
+        return result.DidRun;
+    }
+}
+
+public sealed record ScanResultCoordinatorOptions
+{
+    public required FlowLogDispatcher FlowLogDispatcher { get; init; }
+    public required string FlowLogFallbackCategory { get; init; }
+    public required MainViewModelResultApplier ResultApplier { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required Func<int> GameCountAccessor { get; init; }
+    public required Func<string> RemoteCatalogErrorCodeAccessor { get; init; }
+    public required Func<bool> ReadSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<bool> SetSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<MainViewModelStateUpdate> ApplyStateUpdate { get; init; }
+    public required Action<ShellViewKind> SetCurrentView { get; init; }
+    public required Func<CancellationToken, bool, Task> RecomputeSelectionAfterScanAsync { get; init; }
+}


### PR DESCRIPTION
## Summary
- Add `ScanResultCoordinator` for scan result application, startup no-games navigation, and startup auto-selection suppression.
- Reduce `ScanOrchestrator` / `ScanOrchestratorFactoryInput` scan result callbacks to a single coordinator dependency.
- Keep install flow and install planning code unchanged.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln`
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check`
- Confirmed no diff under `OptiClick.Core`, `OptiClick.Infrastructure`, or install-related WPF paths.