### PR TITLE
[codex] Remove shell command proxies

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.Commands.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.Commands.cs
@@ -1,4 +1,3 @@
-using System.Windows.Input;
 using OptiClick.Wpf.ViewModels.Shell;
 
 namespace OptiClick.Wpf.ViewModels;
@@ -6,22 +5,6 @@ namespace OptiClick.Wpf.ViewModels;
 public sealed partial class MainViewModel
 {
     private RelayCommand _openGameSupportRequestCommand = null!;
-
-    public ICommand SelectGameCommand => Home.SelectGameCommand;
-    public ICommand ShowHomeCommand => Commands.ShowHomeCommand;
-    public ICommand ShowSupportedGamesWikiViewCommand => Commands.ShowSupportedGamesWikiViewCommand;
-    public ICommand ShowScanViewCommand => Commands.ShowScanViewCommand;
-    public ICommand ShowSettingsCommand => Commands.ShowSettingsCommand;
-    public ICommand AddScanFolderCommand => Scan.AddScanFolderCommand;
-    public ICommand RemoveScanFolderCommand => Scan.RemoveScanFolderCommand;
-    public ICommand OpenScanFolderCommand => Scan.OpenScanFolderCommand;
-    public ICommand SaveAndScanCommand => Scan.SaveAndScanCommand;
-    public ICommand OpenLogFolderCommand => Settings.OpenLogFolderCommand;
-    public ICommand OpenSupportRequestCommand => Settings.OpenSupportRequestCommand;
-    public ICommand OpenGameSupportRequestCommand => _openGameSupportRequestCommand;
-    public ICommand RefreshInstallFilesCommand => Settings.RefreshInstallFilesCommand;
-    public ICommand ShowDetailsCommand => Home.ShowDetailsCommand;
-    public ICommand ShowInstallCommand => Home.ShowInstallCommand;
 
     private void InitializeCommandSet()
     {

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -249,6 +249,7 @@ public sealed partial class MainViewModel : ViewModelBase
         RuntimeHeader = new RuntimeHeaderViewModel();
         StartupOverlay = new StartupOverlayViewModel();
         ShellBusyState = new ShellBusyStateViewModel();
+        InitializeCommandSet();
         var scanResultCoordinator = new ScanResultCoordinator(
             new ScanResultCoordinatorOptions
             {
@@ -321,7 +322,7 @@ public sealed partial class MainViewModel : ViewModelBase
                     StringsAccessor = () => Strings,
                     SelectedLanguageAccessor = () => SelectedLanguage,
                     CurrentViewKindAccessor = () => CurrentViewKind,
-                    OpenGameSupportRequestCommandAccessor = () => OpenGameSupportRequestCommand,
+                    OpenGameSupportRequestCommandAccessor = () => _openGameSupportRequestCommand,
                     UpdateStartupPreparationState = UpdateStartupPreparationState
                 },
                 Settings = new SettingsSectionFactoryInput
@@ -348,7 +349,6 @@ public sealed partial class MainViewModel : ViewModelBase
         Scan.PropertyChanged += OnScanSectionPropertyChanged;
         Settings = sections.Settings;
         Settings.PropertyChanged += OnSettingsSectionPropertyChanged;
-        InitializeCommandSet();
 
         _selectedLanguage = _languageProvider.CurrentLanguage;
         RefreshLocalizedStrings();


### PR DESCRIPTION
## Summary
- Remove root-level `MainViewModel` command proxy properties for section commands.
- Keep shell navigation commands exposed through `Commands` and section actions exposed through their section view models.
- Pass the game support request command to the supported-games section without re-exposing it as a root command proxy.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln`
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check`
- Confirmed no diff under `OptiClick.Core`, `OptiClick.Infrastructure`, or install-related WPF paths.

## Notes
- Local-only tests were updated in the ignored `tests/` tree to call `viewModel.Commands`, `viewModel.Home`, `viewModel.Scan`, `viewModel.Settings`, and `viewModel.SupportedGames` command surfaces directly. Those local-only test files are intentionally not part of this public PR.