### PR TITLE
[codex] Move runtime header text update logic

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.InstallAndState.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.InstallAndState.cs
@@ -469,13 +469,7 @@ public sealed partial class MainViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(update);
         if (!string.IsNullOrWhiteSpace(update.ScanStatusText)) ScanStatusText = update.ScanStatusText;
         if (!string.IsNullOrWhiteSpace(update.SettingsStatusText)) SettingsStatusText = update.SettingsStatusText;
-        if (!string.IsNullOrWhiteSpace(update.DeviceText) || !string.IsNullOrWhiteSpace(update.GpuText))
-        {
-            RuntimeHeader.ApplyText(
-                string.IsNullOrWhiteSpace(update.DeviceText) ? RuntimeHeader.DeviceText : update.DeviceText,
-                string.IsNullOrWhiteSpace(update.GpuText) ? RuntimeHeader.GpuText : update.GpuText);
-        }
-
+        RuntimeHeader.ApplyTextUpdate(update.DeviceText, update.GpuText);
         if (update.ShouldRelocalizeScanFolders) RelocalizeScanFolderRows();
         if (update.ShouldRefreshRuntimeSummary) ApplyRuntimeSummaryStateUpdate(_runtimeSummaryStateController.Build(_runtimeShellState.LatestRuntimeContext, Strings));
     }

--- a/OptiClick.Wpf/ViewModels/Shell/RuntimeHeaderViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/Shell/RuntimeHeaderViewModel.cs
@@ -101,6 +101,18 @@ public sealed class RuntimeHeaderViewModel : ViewModelBase
         GpuText = gpuText;
     }
 
+    public void ApplyTextUpdate(string deviceText, string gpuText)
+    {
+        if (string.IsNullOrWhiteSpace(deviceText) && string.IsNullOrWhiteSpace(gpuText))
+        {
+            return;
+        }
+
+        ApplyText(
+            string.IsNullOrWhiteSpace(deviceText) ? DeviceText : deviceText,
+            string.IsNullOrWhiteSpace(gpuText) ? GpuText : gpuText);
+    }
+
     public void Apply(RuntimeSummaryStateUpdate update)
     {
         ArgumentNullException.ThrowIfNull(update);


### PR DESCRIPTION
## Summary
- Add `RuntimeHeaderViewModel.ApplyTextUpdate()` so the runtime header owns partial text update behavior.
- Simplify localization state application in `MainViewModel` to delegate device/GPU text preservation to `RuntimeHeaderViewModel`.
- Keep runtime detection, install flow, and install planning behavior unchanged.

## Validation
- `dotnet build .\OptiClick.Dev.sln` after one transient WPF generated-file failure rerun successfully.
- `dotnet test .\OptiClick.Dev.sln`
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check`
- Confirmed no diff under `OptiClick.Core`, `OptiClick.Infrastructure`, or install-related WPF paths.