### PR TITLE
[codex] Reduce main view model section proxies

### DIFF
--- a/OptiClick.Wpf/ViewModels/MainViewModel.Behaviors.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.Behaviors.cs
@@ -104,7 +104,7 @@ public sealed partial class MainViewModel : ViewModelBase
                 });
                 StartStartupDialogsInBackground();
             },
-            StartSupportedGamesWikiRefreshInBackground = StartSupportedGamesWikiRefreshInBackground,
+            StartSupportedGamesWikiRefreshInBackground = () => SupportedGames.StartRefreshInBackground(),
             StartGameMasterCoverPrefetchInBackground = StartGameMasterCoverPrefetchInBackground,
             LogInfo = message => LogInfo(MainViewModelLogCategories.App, message)
         };
@@ -811,8 +811,8 @@ public sealed partial class MainViewModel : ViewModelBase
         RefreshNavigationAndScanCommandStates();
         if (view == ShellViewKind.SupportedGamesWiki)
         {
-            EnsureSupportedGamesWikiLoadedForView();
-            QueueSupportedGamesWikiVisibleCoverLoad(0, 0);
+            SupportedGames.EnsureLoadedForView();
+            SupportedGames.QueueVisibleCoverLoad(0, 0);
         }
     }
 
@@ -928,7 +928,7 @@ public sealed partial class MainViewModel : ViewModelBase
 
             if (result.ShouldApplyRemoteDataState && SupportedGames.HasEntries)
             {
-                RebuildSupportedGamesWikiRows();
+                SupportedGames.RebuildRows();
             }
 
             if (update.ShouldRefreshArchiveReadiness)

--- a/OptiClick.Wpf/ViewModels/MainViewModel.ShellAndUpdate.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.ShellAndUpdate.cs
@@ -82,7 +82,7 @@ public sealed partial class MainViewModel : ViewModelBase
             OnPropertyChanged(nameof(SelectedLanguage));
             RefreshLocalizedStrings();
             SelectedGameAction.ApplyLocalization(Strings);
-            RefreshSupportedGamesAfterLanguageChange();
+            SupportedGames.RefreshAfterLanguageChange();
             ApplyLocalizationStateUpdate(_localizationStateController.BuildRefreshState(preferredLanguage, Strings));
         }
 

--- a/OptiClick.Wpf/ViewModels/MainViewModel.SupportedGamesWiki.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.SupportedGamesWiki.cs
@@ -6,38 +6,6 @@ namespace OptiClick.Wpf.ViewModels;
 
 public sealed partial class MainViewModel : ViewModelBase
 {
-    private void EnsureSupportedGamesWikiLoadedForView()
-    {
-        SupportedGames.EnsureLoadedForView();
-    }
-
-    private void StartSupportedGamesWikiRefreshInBackground()
-    {
-        SupportedGames.StartRefreshInBackground();
-    }
-
-    private void RefreshSupportedGamesAfterLanguageChange()
-    {
-        SupportedGames.RefreshAfterLanguageChange();
-    }
-
-    private void RebuildSupportedGamesWikiRows()
-    {
-        SupportedGames.RebuildRows();
-    }
-
-    public void QueueSupportedGamesWikiVisibleCoverLoad(double verticalOffset, double viewportHeight)
-    {
-        SupportedGames.QueueVisibleCoverLoad(verticalOffset, viewportHeight);
-    }
-
-    private IReadOnlyList<SupportedGamesWikiRowViewModel> ResolveSupportedGamesWikiVisibleRows(
-        double verticalOffset,
-        double viewportHeight)
-    {
-        return SupportedGames.ResolveVisibleRows(verticalOffset, viewportHeight);
-    }
-
     internal static string ResolveSupportedGamesWikiCoverSource(
         SupportedGamesWikiEntry entry,
         string defaultCoverSource = CoverImageCacheService.DefaultCoverImageSource)

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -383,11 +383,7 @@ public sealed partial class MainViewModel : ViewModelBase
         var propertyName = e.PropertyName ?? "";
         if (string.IsNullOrWhiteSpace(propertyName))
         {
-            OnPropertyChanged(nameof(DefaultFolders));
-            OnPropertyChanged(nameof(AddedFolders));
             OnPropertyChanged(nameof(ScanStatusText));
-            OnPropertyChanged(nameof(DefaultFoldersEmptyVisibility));
-            OnPropertyChanged(nameof(AddedFoldersEmptyVisibility));
             return;
         }
 
@@ -404,12 +400,10 @@ public sealed partial class MainViewModel : ViewModelBase
         }
     }
 
-    public ObservableCollection<GameCardViewModel> Games => Home.Games;
-    public ObservableCollection<ScanFolderRowViewModel> DefaultFolders => Scan.DefaultFolders;
-    public ObservableCollection<ScanFolderRowViewModel> AddedFolders => Scan.AddedFolders;
+    private ObservableCollection<GameCardViewModel> Games => Home.Games;
     public DialogHostViewModel DialogHost { get; }
     public InstallManagementDialogHostViewModel InstallManagementDialogHost { get; }
-    public SelectedGameActionViewModel SelectedGameAction => Home.SelectedGameAction;
+    private SelectedGameActionViewModel SelectedGameAction => Home.SelectedGameAction;
     public ShellNavigationViewModel Navigation { get; }
     public RuntimeHeaderViewModel RuntimeHeader { get; }
     public StartupOverlayViewModel StartupOverlay { get; }
@@ -419,7 +413,7 @@ public sealed partial class MainViewModel : ViewModelBase
     public ScanSectionViewModel Scan { get; }
     public SupportedGamesSectionViewModel SupportedGames { get; }
     public SettingsSectionViewModel Settings { get; }
-    public bool HasGamesForHomeSelectionMessage => Home.HasGamesForHomeSelectionMessage;
+    private bool HasGamesForHomeSelectionMessage => Home.HasGamesForHomeSelectionMessage;
     public StartupPreparationState StartupPreparationState
     {
         get
@@ -441,14 +435,12 @@ public sealed partial class MainViewModel : ViewModelBase
     public bool IsSupportedGamesWikiViewActive => CurrentViewKind == ShellViewKind.SupportedGamesWiki;
     public bool IsScanViewActive => CurrentViewKind == ShellViewKind.Scan;
     public bool IsSettingsViewActive => CurrentViewKind == ShellViewKind.Settings;
-    public Visibility DefaultFoldersEmptyVisibility => Scan.DefaultFoldersEmptyVisibility;
-    public Visibility AddedFoldersEmptyVisibility => Scan.AddedFoldersEmptyVisibility;
     public string WindowTitleWithVersion => $"{Strings.WindowTitle} v{GetCurrentAppVersion()}";
 
-    public string SettingsStatusText
+    private string SettingsStatusText
     {
         get => Settings.SettingsStatusText;
-        private set => Settings.SettingsStatusText = value;
+        set => Settings.SettingsStatusText = value;
     }
 
     public AppLanguage SelectedLanguage
@@ -473,7 +465,7 @@ public sealed partial class MainViewModel : ViewModelBase
             LogInfo(MainViewModelLogCategories.I18n, $"ui_language_changed source=settings value={ToLanguageCode(language)}");
             RefreshLocalizedStrings();
             SelectedGameAction.ApplyLocalization(Strings);
-            RefreshSupportedGamesAfterLanguageChange();
+            SupportedGames.RefreshAfterLanguageChange();
             ApplyLocalizationStateUpdate(_localizationStateController.BuildRefreshState(language, Strings));
             await RefreshRuntimeContextAsync(cancellationToken);
             await RefreshRuntimeDataCatalogAsync(cancellationToken);
@@ -558,16 +550,16 @@ public sealed partial class MainViewModel : ViewModelBase
         return _systemPreferredLanguage;
     }
 
-    public string ScanStatusText
+    private string ScanStatusText
     {
         get => Scan.ScanStatusText;
-        private set => Scan.ScanStatusText = value;
+        set => Scan.ScanStatusText = value;
     }
 
-    public GameCardViewModel? SelectedGame
+    private GameCardViewModel? SelectedGame
     {
         get => Home.SelectedGame;
-        private set => Home.SelectedGame = value;
+        set => Home.SelectedGame = value;
     }
 
 }


### PR DESCRIPTION
## Summary

- Merged PR #23 into `main` first, then grouped the follow-up cleanup into one branch/PR as requested.
- Removed or privatized remaining `MainViewModel` root proxies for Scan, Home, and Settings section state.
- Replaced Supported Games wrapper forwarding methods with direct `SupportedGames` section calls while keeping the existing cover resolver helpers.

## Safety

- No install logic changes.
- No staged diff under `OptiClick.Core`, `OptiClick.Infrastructure`, `OptiClick.Wpf/Install`, `OptiClick.Wpf/Services/Install`, or `OptiClick.Wpf/Shell/Install`.
- Local-only tests were updated and used for validation, but they are not part of the public PR.

## Validation

- Step 1 Scan proxy cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Step 2 Home proxy cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Step 3 Settings proxy cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Step 4 Supported Games wrapper cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Final validation: `dotnet build .\OptiClick.Dev.sln`
- Final validation: `dotnet test .\OptiClick.Dev.sln` (1,659 passed)
- Final validation: `dotnet build .\OptiClick.sln -c Release`
- Final validation: `git diff --check --cached`