### PR TITLE
[codex] Move shell view model composition out of main view model

### DIFF
--- a/OptiClick.Wpf/Composition/MainWindowComposition.cs
+++ b/OptiClick.Wpf/Composition/MainWindowComposition.cs
@@ -16,7 +16,9 @@ using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels;
+using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Shell;
 using System.Net.Http;
 
 namespace OptiClick.Wpf.Composition;
@@ -63,6 +65,7 @@ public sealed class MainWindowComposition
             runtime.DeviceIdentityResolver,
             runtimeHeaderPresenter);
         var navigationState = new ShellNavigationState();
+        var shellChrome = ShellChromeViewModels.Create(navigationState);
         var dialogPresenter = new DialogPresenter(app.DialogService, app.AppLogger);
         var remoteCatalogDialogGate = new OnceDialogGate();
         var userSettingsController = new UserSettingsController(app.UserSettingsStore, app.AppLogger);
@@ -91,6 +94,7 @@ public sealed class MainWindowComposition
             app.LocalDataPathProvider,
             app.AppLogger);
         var busyStateApplier = new MainViewModelBusyStateApplier();
+        var shellSectionsFactory = new ShellSectionsFactory();
         var viewModelFactory = new MainViewModelFactory();
 
         return viewModelFactory.Create(new MainViewModelFactoryInput
@@ -180,6 +184,7 @@ public sealed class MainWindowComposition
                 SupportActionController = support.SupportActionController,
                 SupportIssueContextBuilder = support.SupportIssueContextBuilder,
                 NavigationState = navigationState,
+                ShellChrome = shellChrome,
                 DialogPresenter = dialogPresenter,
                 RemoteCatalogDialogGate = remoteCatalogDialogGate,
                 UserSettingsController = userSettingsController,
@@ -194,6 +199,7 @@ public sealed class MainWindowComposition
                 FlowLogDispatcher = flowLogDispatcher,
                 FlowRequestFactory = flowRequestFactory,
                 ResultApplier = resultApplier,
+                ShellSectionsFactory = shellSectionsFactory,
                 GameCardSelectionStateController = gameCardSelectionStateController,
                 GameMasterCoverPrefetchService = gameMasterCoverPrefetchService,
                 CoverCacheBootstrapService = coverCacheBootstrapService,

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -245,10 +245,10 @@ public sealed partial class MainViewModel : ViewModelBase
             ? new ObservableCollection<ScanFolderRowViewModel>(_mockDataProvider.CreateAddedFolders())
             : new ObservableCollection<ScanFolderRowViewModel>(LoadAddedScanFoldersFromManifest(defaultFolders, scanFolderActionController));
         var settingsLanguageOptions = new ObservableCollection<string> { LanguageOptionAuto, LanguageOptionKorean, LanguageOptionEnglish };
-        Navigation = new ShellNavigationViewModel(_navigationState);
-        RuntimeHeader = new RuntimeHeaderViewModel();
-        StartupOverlay = new StartupOverlayViewModel();
-        ShellBusyState = new ShellBusyStateViewModel();
+        Navigation = resolved.ShellChrome.Navigation;
+        RuntimeHeader = resolved.ShellChrome.RuntimeHeader;
+        StartupOverlay = resolved.ShellChrome.StartupOverlay;
+        ShellBusyState = resolved.ShellChrome.ShellBusyState;
         InitializeCommandSet();
         var scanResultCoordinator = new ScanResultCoordinator(
             new ScanResultCoordinatorOptions
@@ -280,7 +280,7 @@ public sealed partial class MainViewModel : ViewModelBase
                 ClearVisibleGameCards = () => ReplaceGameCards([]),
                 LogWarning = message => LogWarning(MainViewModelLogCategories.Scan, message)
             });
-        var sections = new ShellSectionsFactory().Create(
+        var sections = resolved.ShellSectionsFactory.Create(
             new ShellSectionsFactoryInput
             {
                 Home = new HomeSectionFactoryInput

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
@@ -27,7 +27,9 @@ using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Shell;
 using OptiClick.Infrastructure.FileSystem;
 
 namespace OptiClick.Wpf.ViewModels;
@@ -119,6 +121,7 @@ public sealed record MainViewModelAppDependencies
     public SupportActionController? SupportActionController { get; init; }
     public SupportIssueContextBuilder? SupportIssueContextBuilder { get; init; }
     public ShellNavigationState? NavigationState { get; init; }
+    public ShellChromeViewModels? ShellChrome { get; init; }
     public DialogPresenter? DialogPresenter { get; init; }
     public OnceDialogGate? RemoteCatalogDialogGate { get; init; }
     public RuntimeHeaderPresenter? RuntimeHeaderPresenter { get; init; }
@@ -133,6 +136,7 @@ public sealed record MainViewModelAppDependencies
     public FlowLogDispatcher? FlowLogDispatcher { get; init; }
     public MainViewModelFlowRequestFactory? FlowRequestFactory { get; init; }
     public MainViewModelResultApplier? ResultApplier { get; init; }
+    public ShellSectionsFactory? ShellSectionsFactory { get; init; }
     public GameCardSelectionStateController? GameCardSelectionStateController { get; init; }
     public IGameMasterCoverPrefetchService? GameMasterCoverPrefetchService { get; init; }
     public ICoverCacheBootstrapService? CoverCacheBootstrapService { get; init; }

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
@@ -99,8 +99,20 @@ public static class MainViewModelDependencyResolver
 
         var resolvedUserSettingsStore = appDependencies.UserSettingsStore ?? new AppUserSettingsStore(localDataPathProvider, appLogger);
         var firstRunStateStore = appDependencies.FirstRunStateStore ?? new FirstRunStateStore(localDataPathProvider, appLogger);
-        var navigationState = appDependencies.NavigationState ?? new ShellNavigationState();
-        var shellChrome = appDependencies.ShellChrome ?? ShellChromeViewModels.Create(navigationState);
+        ShellNavigationState navigationState;
+        ShellChromeViewModels shellChrome;
+        if (appDependencies.ShellChrome is null)
+        {
+            navigationState = appDependencies.NavigationState ?? new ShellNavigationState();
+            shellChrome = ShellChromeViewModels.Create(navigationState);
+        }
+        else
+        {
+            shellChrome = appDependencies.ShellChrome;
+            navigationState = appDependencies.NavigationState ?? shellChrome.NavigationState;
+            EnsureShellChromeNavigationState(shellChrome, navigationState);
+        }
+
         var dialogPresenter = appDependencies.DialogPresenter ?? new DialogPresenter(required.DialogService, appLogger);
         var remoteCatalogDialogGate = appDependencies.RemoteCatalogDialogGate ?? new OnceDialogGate();
         var resolvedGpuVendorLogoResolver = appDependencies.GpuVendorLogoResolver ?? new GpuVendorLogoResolver();
@@ -369,5 +381,18 @@ public static class MainViewModelDependencyResolver
 
         throw new InvalidOperationException(
             $"MainViewModel dependency '{dependencyName}' must be explicitly provided when fallback resolution is disabled.");
+    }
+
+    private static void EnsureShellChromeNavigationState(
+        ShellChromeViewModels shellChrome,
+        ShellNavigationState navigationState)
+    {
+        if (ReferenceEquals(shellChrome.NavigationState, navigationState))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "MainViewModel dependency 'ShellChrome.NavigationState' must reference the same instance as 'NavigationState'.");
     }
 }

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
@@ -25,7 +25,9 @@ using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Shell;
 using OptiClick.Infrastructure.FileSystem;
 using System.Net.Http;
 
@@ -98,6 +100,7 @@ public static class MainViewModelDependencyResolver
         var resolvedUserSettingsStore = appDependencies.UserSettingsStore ?? new AppUserSettingsStore(localDataPathProvider, appLogger);
         var firstRunStateStore = appDependencies.FirstRunStateStore ?? new FirstRunStateStore(localDataPathProvider, appLogger);
         var navigationState = appDependencies.NavigationState ?? new ShellNavigationState();
+        var shellChrome = appDependencies.ShellChrome ?? ShellChromeViewModels.Create(navigationState);
         var dialogPresenter = appDependencies.DialogPresenter ?? new DialogPresenter(required.DialogService, appLogger);
         var remoteCatalogDialogGate = appDependencies.RemoteCatalogDialogGate ?? new OnceDialogGate();
         var resolvedGpuVendorLogoResolver = appDependencies.GpuVendorLogoResolver ?? new GpuVendorLogoResolver();
@@ -200,6 +203,7 @@ public static class MainViewModelDependencyResolver
         var installManagementDialogService = appDependencies.InstallManagementDialogService
                                              ?? new OverlayInstallManagementDialogService(installManagementDialogHost);
         var resultApplier = appDependencies.ResultApplier ?? new MainViewModelResultApplier();
+        var shellSectionsFactory = appDependencies.ShellSectionsFactory ?? new ShellSectionsFactory();
         var gameCardSelectionStateController = appDependencies.GameCardSelectionStateController ?? new GameCardSelectionStateController();
         var startupBackgroundTaskManager = appDependencies.StartupBackgroundTaskManager ?? new StartupBackgroundTaskManager();
         var archiveReadinessRefreshCoordinator = appDependencies.ArchiveReadinessRefreshCoordinator ?? new ArchiveReadinessRefreshCoordinator();
@@ -234,6 +238,7 @@ public static class MainViewModelDependencyResolver
             AppStringsProvider = appStringsProvider,
             FirstRunStateStore = firstRunStateStore,
             NavigationState = navigationState,
+            ShellChrome = shellChrome,
             DialogPresenter = dialogPresenter,
             InstallManagementDialogHost = installManagementDialogHost,
             InstallManagementDialogService = installManagementDialogService,
@@ -259,6 +264,7 @@ public static class MainViewModelDependencyResolver
             FlowRequestFactory = flowRequestFactory,
             DialogHost = dialogHost,
             ResultApplier = resultApplier,
+            ShellSectionsFactory = shellSectionsFactory,
             GameCardSelectionStateController = gameCardSelectionStateController,
             GameMasterCoverPrefetchService = resolvedGameMasterCoverPrefetchService,
             CoverCacheBootstrapService = resolvedCoverCacheBootstrapService,
@@ -317,6 +323,7 @@ public static class MainViewModelDependencyResolver
         EnsureExplicitDependency(appDependencies.GameCardSelectionStateController, nameof(MainViewModelAppDependencies.GameCardSelectionStateController));
         EnsureExplicitDependency(appDependencies.InstallManagementDialogHost, nameof(MainViewModelAppDependencies.InstallManagementDialogHost));
         EnsureExplicitDependency(appDependencies.InstallManagementDialogService, nameof(MainViewModelAppDependencies.InstallManagementDialogService));
+        EnsureExplicitDependency(appDependencies.ShellChrome, nameof(MainViewModelAppDependencies.ShellChrome));
         EnsureExplicitDependency(appDependencies.AppVersionProvider, nameof(MainViewModelAppDependencies.AppVersionProvider));
         EnsureExplicitDependency(appDependencies.AppUpdateFlowController, nameof(MainViewModelAppDependencies.AppUpdateFlowController));
         EnsureExplicitDependency(appDependencies.GameDetailsDialogPresenter, nameof(MainViewModelAppDependencies.GameDetailsDialogPresenter));
@@ -331,6 +338,7 @@ public static class MainViewModelDependencyResolver
         EnsureExplicitDependency(appDependencies.FlowLogDispatcher, nameof(MainViewModelAppDependencies.FlowLogDispatcher));
         EnsureExplicitDependency(appDependencies.FlowRequestFactory, nameof(MainViewModelAppDependencies.FlowRequestFactory));
         EnsureExplicitDependency(appDependencies.ResultApplier, nameof(MainViewModelAppDependencies.ResultApplier));
+        EnsureExplicitDependency(appDependencies.ShellSectionsFactory, nameof(MainViewModelAppDependencies.ShellSectionsFactory));
         EnsureExplicitDependency(appDependencies.DialogHost, nameof(MainViewModelAppDependencies.DialogHost));
         EnsureExplicitDependency(
             appDependencies.GameMasterCoverPrefetchService,

--- a/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
@@ -22,7 +22,9 @@ using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Shell;
 using OptiClick.Infrastructure.FileSystem;
 
 namespace OptiClick.Wpf.ViewModels;
@@ -59,6 +61,7 @@ public sealed record MainViewModelResolvedDependencies
     public required IAppStringsProvider AppStringsProvider { get; init; }
     public required IFirstRunStateStore FirstRunStateStore { get; init; }
     public required ShellNavigationState NavigationState { get; init; }
+    public required ShellChromeViewModels ShellChrome { get; init; }
     public required DialogPresenter DialogPresenter { get; init; }
     public required InstallManagementDialogHostViewModel InstallManagementDialogHost { get; init; }
     public required IInstallManagementDialogService InstallManagementDialogService { get; init; }
@@ -84,6 +87,7 @@ public sealed record MainViewModelResolvedDependencies
     public required MainViewModelFlowRequestFactory FlowRequestFactory { get; init; }
     public required DialogHostViewModel DialogHost { get; init; }
     public required MainViewModelResultApplier ResultApplier { get; init; }
+    public required ShellSectionsFactory ShellSectionsFactory { get; init; }
     public required GameCardSelectionStateController GameCardSelectionStateController { get; init; }
     public required IGameMasterCoverPrefetchService GameMasterCoverPrefetchService { get; init; }
     public required ICoverCacheBootstrapService CoverCacheBootstrapService { get; init; }

--- a/OptiClick.Wpf/ViewModels/Shell/ShellChromeViewModels.cs
+++ b/OptiClick.Wpf/ViewModels/Shell/ShellChromeViewModels.cs
@@ -3,6 +3,7 @@ using OptiClick.Wpf.Shell.Navigation;
 namespace OptiClick.Wpf.ViewModels.Shell;
 
 public sealed record ShellChromeViewModels(
+    ShellNavigationState NavigationState,
     ShellNavigationViewModel Navigation,
     RuntimeHeaderViewModel RuntimeHeader,
     StartupOverlayViewModel StartupOverlay,
@@ -13,6 +14,7 @@ public sealed record ShellChromeViewModels(
         ArgumentNullException.ThrowIfNull(navigationState);
 
         return new ShellChromeViewModels(
+            navigationState,
             new ShellNavigationViewModel(navigationState),
             new RuntimeHeaderViewModel(),
             new StartupOverlayViewModel(),

--- a/OptiClick.Wpf/ViewModels/Shell/ShellChromeViewModels.cs
+++ b/OptiClick.Wpf/ViewModels/Shell/ShellChromeViewModels.cs
@@ -1,0 +1,21 @@
+using OptiClick.Wpf.Shell.Navigation;
+
+namespace OptiClick.Wpf.ViewModels.Shell;
+
+public sealed record ShellChromeViewModels(
+    ShellNavigationViewModel Navigation,
+    RuntimeHeaderViewModel RuntimeHeader,
+    StartupOverlayViewModel StartupOverlay,
+    ShellBusyStateViewModel ShellBusyState)
+{
+    public static ShellChromeViewModels Create(ShellNavigationState navigationState)
+    {
+        ArgumentNullException.ThrowIfNull(navigationState);
+
+        return new ShellChromeViewModels(
+            new ShellNavigationViewModel(navigationState),
+            new RuntimeHeaderViewModel(),
+            new StartupOverlayViewModel(),
+            new ShellBusyStateViewModel());
+    }
+}


### PR DESCRIPTION
## Summary

- Merged PR #25 into `main` first, then continued the composition cleanup in one branch/PR.
- Added `ShellSectionsFactory` to the resolved dependency graph so `MainViewModel` no longer directly creates the section factory.
- Added `ShellChromeViewModels` to group the root shell binding VMs (`Navigation`, `RuntimeHeader`, `StartupOverlay`, `ShellBusyState`) and create them from Composition/Resolver instead of inside `MainViewModel`.

## Safety

- No install logic changes.
- No staged diff under `OptiClick.Core`, `OptiClick.Infrastructure`, `OptiClick.Wpf/Install`, `OptiClick.Wpf/Services/Install`, or `OptiClick.Wpf/Shell/Install`.
- Local-only tests were updated and used for validation, but they are not part of the public PR.

## Validation

- Step 1 ShellSectionsFactory dependency cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Step 2 ShellChromeViewModels composition cleanup: `dotnet build .\OptiClick.Dev.sln` and `dotnet test .\OptiClick.Dev.sln`
- Final validation: `dotnet build .\OptiClick.sln -c Release`
- Final validation: `git diff --check`
- Final validation: `git diff --cached --check`