### PR TITLE
[codex] Reduce MainViewModel composition responsibilities

### DIFF
--- a/OptiClick.Wpf/Composition/MainWindowComposition.cs
+++ b/OptiClick.Wpf/Composition/MainWindowComposition.cs
@@ -8,12 +8,15 @@ using OptiClick.Wpf.Shell.Actions;
 using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Flow;
 using OptiClick.Wpf.Shell.Games;
+using OptiClick.Wpf.Shell.Gpu;
 using OptiClick.Wpf.Shell.Localization;
 using OptiClick.Wpf.Shell.Navigation;
 using OptiClick.Wpf.Shell.Runtime;
 using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Startup;
+using OptiClick.Wpf.Shell.Update;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels;
 using OptiClick.Wpf.ViewModels.Sections;
@@ -53,6 +56,7 @@ public sealed class MainWindowComposition
             scanFolderListController,
             scan.FolderPickerService,
             scanFolderDialogPresenter);
+        var scanResultCoordinatorFactory = new ScanResultCoordinatorFactory();
         var scanOrchestratorFactory = new ScanOrchestratorFactory();
         var startupNoticePresenter = new StartupNoticePresenter();
         var gameMasterCoverPrefetchService = new GameMasterCoverPrefetchService();
@@ -64,6 +68,15 @@ public sealed class MainWindowComposition
         var runtimeSummaryStateController = new RuntimeSummaryStateController(
             runtime.DeviceIdentityResolver,
             runtimeHeaderPresenter);
+        var gpuSelectionCoordinator = new GpuSelectionCoordinator(GpuSelectionCoordinator.DefaultMaxSupportedGpuCount);
+        var runtimeContextCoordinator = new RuntimeContextCoordinator(
+            runtime.RuntimeContextFlowController,
+            runtimeSummaryStateController,
+            flowLogDispatcher,
+            gpuSelectionCoordinator);
+        var runtimeCatalogCoordinator = new RuntimeCatalogCoordinator(
+            runtime.RuntimeCatalogFlowController,
+            runtime.RuntimeEndpointStatusPresenter);
         var navigationState = new ShellNavigationState();
         var shellChrome = ShellChromeViewModels.Create(navigationState);
         var dialogPresenter = new DialogPresenter(app.DialogService, app.AppLogger);
@@ -77,6 +90,12 @@ public sealed class MainWindowComposition
             new SupportedGamesWikiMarkdownCacheStore(app.LocalDataPathProvider, app.AppLogger),
             app.AppLogger);
         var startupAnnouncementFlowController = new StartupAnnouncementFlowController(startupNoticePresenter);
+        var selectionPopupCoordinator = new SelectionPopupCoordinator(
+            install.GameSelectionFlowController,
+            dialogPresenter,
+            flowLogDispatcher,
+            app.AppLogger);
+        var appUpdateCoordinator = new AppUpdateCoordinator(update.AppUpdateFlowController);
         var gameCardSelectionStateController = new GameCardSelectionStateController();
         var startupBackgroundTaskManager = new StartupBackgroundTaskManager();
         var archiveReadinessRefreshCoordinator = new ArchiveReadinessRefreshCoordinator();
@@ -119,6 +138,9 @@ public sealed class MainWindowComposition
                 DeviceIdentityRulesFlowController = runtime.DeviceIdentityRulesFlowController,
                 RuntimeCatalogFlowController = runtime.RuntimeCatalogFlowController,
                 RuntimeEndpointStatusPresenter = runtime.RuntimeEndpointStatusPresenter,
+                GpuSelectionCoordinator = gpuSelectionCoordinator,
+                RuntimeContextCoordinator = runtimeContextCoordinator,
+                RuntimeCatalogCoordinator = runtimeCatalogCoordinator,
                 ModuleDownloadLinkMapBuilder = runtime.ModuleDownloadLinkMapBuilder,
                 GpuBundleManifestClient = runtime.GpuBundleManifestClient,
                 GpuBundleManifestRuleResolver = runtime.GpuBundleManifestRuleResolver
@@ -133,6 +155,7 @@ public sealed class MainWindowComposition
                 ScanFolderListController = scanFolderListController,
                 ScanFolderDialogPresenter = scanFolderDialogPresenter,
                 ScanFolderActionController = scanFolderActionController,
+                ScanResultCoordinatorFactory = scanResultCoordinatorFactory,
                 ScanOrchestratorFactory = scanOrchestratorFactory
             },
             Install = new MainViewModelInstallDependencies
@@ -169,6 +192,7 @@ public sealed class MainWindowComposition
                 AppUpdateExecutionService = update.AppUpdateExecutionService,
                 AppUpdateDialogPresenter = update.AppUpdateDialogPresenter,
                 AppUpdateFlowController = update.AppUpdateFlowController,
+                AppUpdateCoordinator = appUpdateCoordinator,
                 GameDetailsDialogPresenter = support.GameDetailsDialogPresenter,
                 AppLogger = app.AppLogger,
                 LocalDataPathProvider = app.LocalDataPathProvider,
@@ -192,6 +216,7 @@ public sealed class MainWindowComposition
                 RuntimeHeaderPresenter = runtimeHeaderPresenter,
                 StartupNoticePresenter = startupNoticePresenter,
                 StartupAnnouncementFlowController = startupAnnouncementFlowController,
+                SelectionPopupCoordinator = selectionPopupCoordinator,
                 ShellCommandActionController = shellCommandActionController,
                 LocalizationStateController = localizationStateController,
                 RuntimeSummaryStateController = runtimeSummaryStateController,

--- a/OptiClick.Wpf/Shell/Gpu/GpuSelectionCoordinator.cs
+++ b/OptiClick.Wpf/Shell/Gpu/GpuSelectionCoordinator.cs
@@ -5,6 +5,8 @@ namespace OptiClick.Wpf.Shell.Gpu;
 
 public sealed class GpuSelectionCoordinator
 {
+    public const int DefaultMaxSupportedGpuCount = 2;
+
     private readonly int _maxSupportedGpuCount;
     private bool _multiGpuBlockPopupShown;
     private string _multiGpuBlockPopupSignature = "";

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -49,7 +49,6 @@ namespace OptiClick.Wpf.ViewModels;
 
 public sealed partial class MainViewModel : ViewModelBase
 {
-    private const int MaxSupportedGpuCount = 2;
     private const string LanguagePreferenceAuto = "auto";
     private const string LanguagePreferenceKorean = "ko";
     private const string LanguagePreferenceEnglish = "en";
@@ -167,10 +166,7 @@ public sealed partial class MainViewModel : ViewModelBase
         _mockDataProvider = resolved.MockDataProvider;
         _operatingSystemSupportPolicy = resolved.OperatingSystemSupportPolicy;
         _shellGameCardViewModelFactory = resolved.ShellGameCardViewModelFactory;
-        var runtimeContextFlowController = resolved.RuntimeContextFlowController;
         _deviceIdentityRulesFlowController = resolved.DeviceIdentityRulesFlowController;
-        var runtimeCatalogFlowController = resolved.RuntimeCatalogFlowController;
-        var runtimeEndpointStatusPresenter = resolved.RuntimeEndpointStatusPresenter;
         _gpuBundleManifestClient = resolved.GpuBundleManifestClient;
         _gpuBundleManifestRuleResolver = resolved.GpuBundleManifestRuleResolver;
         _gameSelectionFlowController = resolved.GameSelectionFlowController;
@@ -209,7 +205,7 @@ public sealed partial class MainViewModel : ViewModelBase
         var supportedGamesWikiMarkdownLoader = resolved.SupportedGamesWikiMarkdownLoader;
         _busyStateApplier = resolved.BusyStateApplier;
         _appUpdateFlowController = resolved.AppUpdateFlowController;
-        _appUpdateCoordinator = new AppUpdateCoordinator(_appUpdateFlowController);
+        _appUpdateCoordinator = resolved.AppUpdateCoordinator;
         _gameDetailsDialogPresenter = resolved.GameDetailsDialogPresenter;
         _gameCardSelectionStateController = resolved.GameCardSelectionStateController;
         _gameMasterCoverPrefetchService = resolved.GameMasterCoverPrefetchService;
@@ -218,20 +214,10 @@ public sealed partial class MainViewModel : ViewModelBase
         _archiveReadinessRefreshCoordinator = resolved.ArchiveReadinessRefreshCoordinator;
         _archiveReadinessWarmupController = resolved.ArchiveReadinessWarmupController;
         _startupFlowCoordinator = resolved.StartupFlowCoordinator;
-        _selectionPopupCoordinator = new SelectionPopupCoordinator(
-            _gameSelectionFlowController,
-            _dialogPresenter,
-            _flowLogDispatcher,
-            _appLogger);
-        _gpuSelectionCoordinator = new GpuSelectionCoordinator(MaxSupportedGpuCount);
-        _runtimeContextCoordinator = new RuntimeContextCoordinator(
-            runtimeContextFlowController,
-            _runtimeSummaryStateController,
-            _flowLogDispatcher,
-            _gpuSelectionCoordinator);
-        _runtimeCatalogCoordinator = new RuntimeCatalogCoordinator(
-            runtimeCatalogFlowController,
-            runtimeEndpointStatusPresenter);
+        _selectionPopupCoordinator = resolved.SelectionPopupCoordinator;
+        _gpuSelectionCoordinator = resolved.GpuSelectionCoordinator;
+        _runtimeContextCoordinator = resolved.RuntimeContextCoordinator;
+        _runtimeCatalogCoordinator = resolved.RuntimeCatalogCoordinator;
         DialogHost = resolved.DialogHost;
         InstallManagementDialogHost = resolved.InstallManagementDialogHost;
         var games = seedMockGameCards
@@ -250,8 +236,8 @@ public sealed partial class MainViewModel : ViewModelBase
         StartupOverlay = resolved.ShellChrome.StartupOverlay;
         ShellBusyState = resolved.ShellChrome.ShellBusyState;
         InitializeCommandSet();
-        var scanResultCoordinator = new ScanResultCoordinator(
-            new ScanResultCoordinatorOptions
+        var scanResultCoordinator = resolved.ScanResultCoordinatorFactory.Create(
+            new ScanResultCoordinatorFactoryInput
             {
                 FlowLogDispatcher = _flowLogDispatcher,
                 FlowLogFallbackCategory = MainViewModelLogCategories.Scan,

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
@@ -18,6 +18,7 @@ using OptiClick.Wpf.Shell.Actions;
 using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Flow;
 using OptiClick.Wpf.Shell.Games;
+using OptiClick.Wpf.Shell.Gpu;
 using OptiClick.Wpf.Shell.Localization;
 using OptiClick.Wpf.Shell.Navigation;
 using OptiClick.Wpf.Shell.Runtime;
@@ -26,6 +27,7 @@ using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Selection;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
+using OptiClick.Wpf.Shell.Update;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
@@ -53,6 +55,9 @@ public sealed record MainViewModelRuntimeDependencies
     public DeviceIdentityRulesFlowController? DeviceIdentityRulesFlowController { get; init; }
     public RuntimeCatalogFlowController? RuntimeCatalogFlowController { get; init; }
     public RuntimeEndpointStatusPresenter? RuntimeEndpointStatusPresenter { get; init; }
+    public GpuSelectionCoordinator? GpuSelectionCoordinator { get; init; }
+    public RuntimeContextCoordinator? RuntimeContextCoordinator { get; init; }
+    public RuntimeCatalogCoordinator? RuntimeCatalogCoordinator { get; init; }
     public ModuleDownloadLinkMapBuilder? ModuleDownloadLinkMapBuilder { get; init; }
     public IRemoteGpuBundleManifestClient? GpuBundleManifestClient { get; init; }
     public IGpuBundleManifestRuleResolver? GpuBundleManifestRuleResolver { get; init; }
@@ -68,6 +73,7 @@ public sealed record MainViewModelScanDependencies
     public ScanFolderListController? ScanFolderListController { get; init; }
     public ScanFolderDialogPresenter? ScanFolderDialogPresenter { get; init; }
     public ScanFolderActionController? ScanFolderActionController { get; init; }
+    public ScanResultCoordinatorFactory? ScanResultCoordinatorFactory { get; init; }
     public ScanOrchestratorFactory? ScanOrchestratorFactory { get; init; }
 }
 
@@ -106,6 +112,7 @@ public sealed record MainViewModelAppDependencies
     public IAppUpdateExecutionService? AppUpdateExecutionService { get; init; }
     public AppUpdateDialogPresenter? AppUpdateDialogPresenter { get; init; }
     public AppUpdateFlowController? AppUpdateFlowController { get; init; }
+    public AppUpdateCoordinator? AppUpdateCoordinator { get; init; }
     public GameDetailsDialogPresenter? GameDetailsDialogPresenter { get; init; }
     public IAppLogger? AppLogger { get; init; }
     public IAppLocalDataPathProvider? LocalDataPathProvider { get; init; }
@@ -129,6 +136,7 @@ public sealed record MainViewModelAppDependencies
     public ISupportedGamesWikiMarkdownLoader? SupportedGamesWikiMarkdownLoader { get; init; }
     public StartupNoticePresenter? StartupNoticePresenter { get; init; }
     public StartupAnnouncementFlowController? StartupAnnouncementFlowController { get; init; }
+    public SelectionPopupCoordinator? SelectionPopupCoordinator { get; init; }
     public ShellCommandActionController? ShellCommandActionController { get; init; }
     public LocalizationStateController? LocalizationStateController { get; init; }
     public RuntimeSummaryStateController? RuntimeSummaryStateController { get; init; }

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
@@ -16,6 +16,7 @@ using OptiClick.Wpf.Shell.Actions;
 using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Flow;
 using OptiClick.Wpf.Shell.Games;
+using OptiClick.Wpf.Shell.Gpu;
 using OptiClick.Wpf.Shell.Localization;
 using OptiClick.Wpf.Shell.Navigation;
 using OptiClick.Wpf.Shell.Runtime;
@@ -24,6 +25,7 @@ using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
+using OptiClick.Wpf.Shell.Update;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
@@ -119,6 +121,18 @@ public static class MainViewModelDependencyResolver
         var runtimeHeaderPresenter = appDependencies.RuntimeHeaderPresenter ?? new RuntimeHeaderPresenter(resolvedGpuVendorLogoResolver);
         var runtimeSummaryStateController = appDependencies.RuntimeSummaryStateController
                                             ?? new RuntimeSummaryStateController(deviceIdentityResolver, runtimeHeaderPresenter);
+        var gpuSelectionCoordinator = runtimeDependencies.GpuSelectionCoordinator
+                                      ?? new GpuSelectionCoordinator(GpuSelectionCoordinator.DefaultMaxSupportedGpuCount);
+        var runtimeContextCoordinator = runtimeDependencies.RuntimeContextCoordinator
+                                        ?? new RuntimeContextCoordinator(
+                                            runtimeContextFlowController,
+                                            runtimeSummaryStateController,
+                                            flowLogDispatcher,
+                                            gpuSelectionCoordinator);
+        var runtimeCatalogCoordinator = runtimeDependencies.RuntimeCatalogCoordinator
+                                        ?? new RuntimeCatalogCoordinator(
+                                            runtimeCatalogFlowController,
+                                            runtimeEndpointStatusPresenter);
         var userSettingsController = appDependencies.UserSettingsController ?? new UserSettingsController(resolvedUserSettingsStore, appLogger);
         var supportedGamesWikiMarkdownLoader = appDependencies.SupportedGamesWikiMarkdownLoader
                                                 ?? new NoopSupportedGamesWikiMarkdownLoader();
@@ -134,6 +148,7 @@ public static class MainViewModelDependencyResolver
                                              scanFolderListController,
                                              scanDependencies.FolderPickerService,
                                              scanFolderDialogPresenter);
+        var scanResultCoordinatorFactory = scanDependencies.ScanResultCoordinatorFactory ?? new ScanResultCoordinatorFactory();
         var scanOrchestratorFactory = scanDependencies.ScanOrchestratorFactory ?? new ScanOrchestratorFactory();
         var supportIssueContextBuilder = appDependencies.SupportIssueContextBuilder ?? new SupportIssueContextBuilder();
 
@@ -209,6 +224,13 @@ public static class MainViewModelDependencyResolver
             resolvedAppUpdateExecutionService,
             resolvedExternalUrlLauncher,
             resolvedAppUpdateDialogPresenter);
+        var appUpdateCoordinator = appDependencies.AppUpdateCoordinator ?? new AppUpdateCoordinator(appUpdateFlowController);
+        var selectionPopupCoordinator = appDependencies.SelectionPopupCoordinator
+                                        ?? new SelectionPopupCoordinator(
+                                            gameSelectionFlowController,
+                                            dialogPresenter,
+                                            flowLogDispatcher,
+                                            appLogger);
         var gameDetailsDialogPresenter = appDependencies.GameDetailsDialogPresenter ?? new GameDetailsDialogPresenter();
         var dialogHost = appDependencies.DialogHost ?? new DialogHostViewModel();
         var installManagementDialogHost = appDependencies.InstallManagementDialogHost ?? new InstallManagementDialogHostViewModel();
@@ -232,6 +254,9 @@ public static class MainViewModelDependencyResolver
             DeviceIdentityRulesFlowController = deviceIdentityRulesFlowController,
             RuntimeCatalogFlowController = runtimeCatalogFlowController,
             RuntimeEndpointStatusPresenter = runtimeEndpointStatusPresenter,
+            GpuSelectionCoordinator = gpuSelectionCoordinator,
+            RuntimeContextCoordinator = runtimeContextCoordinator,
+            RuntimeCatalogCoordinator = runtimeCatalogCoordinator,
             GpuBundleManifestClient = gpuBundleManifestClient,
             GpuBundleManifestRuleResolver = gpuBundleManifestRuleResolver,
             FolderPickerService = scanDependencies.FolderPickerService,
@@ -244,6 +269,7 @@ public static class MainViewModelDependencyResolver
             OptiClickUninstallExecutor = optiClickUninstallExecutor,
             AppVersionProvider = appVersionProvider,
             AppUpdateFlowController = appUpdateFlowController,
+            AppUpdateCoordinator = appUpdateCoordinator,
             GameDetailsDialogPresenter = gameDetailsDialogPresenter,
             AppLogger = appLogger,
             LocalDataPathProvider = localDataPathProvider,
@@ -262,12 +288,14 @@ public static class MainViewModelDependencyResolver
             ScanVisibleGameResolver = scanVisibleGameResolver,
             StartupNoticePresenter = startupNoticePresenter,
             StartupAnnouncementFlowController = startupAnnouncementFlowController,
+            SelectionPopupCoordinator = selectionPopupCoordinator,
             ShellCommandActionController = shellCommandActionController,
             LocalizationStateController = localizationStateController,
             RuntimeSummaryStateController = runtimeSummaryStateController,
             BusyStateApplier = busyStateApplier,
             ScanFolderDialogPresenter = scanFolderDialogPresenter,
             ScanFolderActionController = scanFolderActionController,
+            ScanResultCoordinatorFactory = scanResultCoordinatorFactory,
             ScanOrchestratorFactory = scanOrchestratorFactory,
             SupportActionController = supportActionController,
             SupportIssueContextBuilder = supportIssueContextBuilder,
@@ -309,24 +337,45 @@ public static class MainViewModelDependencyResolver
             return;
         }
 
+        EnsureExplicitRuntimeDependencies(runtimeDependencies);
+        EnsureExplicitScanDependencies(scanDependencies);
+        EnsureExplicitInstallDependencies(installDependencies);
+        EnsureExplicitAppDependencies(appDependencies);
+    }
+
+    private static void EnsureExplicitRuntimeDependencies(MainViewModelRuntimeDependencies runtimeDependencies)
+    {
         EnsureExplicitDependency(runtimeDependencies.RuntimeContextFlowController, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.RuntimeContextFlowController)}");
         EnsureExplicitDependency(runtimeDependencies.DeviceIdentityRulesFlowController, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.DeviceIdentityRulesFlowController)}");
         EnsureExplicitDependency(runtimeDependencies.RuntimeCatalogFlowController, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.RuntimeCatalogFlowController)}");
         EnsureExplicitDependency(runtimeDependencies.RuntimeEndpointStatusPresenter, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.RuntimeEndpointStatusPresenter)}");
+        EnsureExplicitDependency(runtimeDependencies.GpuSelectionCoordinator, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.GpuSelectionCoordinator)}");
+        EnsureExplicitDependency(runtimeDependencies.RuntimeContextCoordinator, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.RuntimeContextCoordinator)}");
+        EnsureExplicitDependency(runtimeDependencies.RuntimeCatalogCoordinator, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.RuntimeCatalogCoordinator)}");
         EnsureExplicitDependency(runtimeDependencies.GpuBundleManifestClient, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.GpuBundleManifestClient)}");
         EnsureExplicitDependency(runtimeDependencies.GpuBundleManifestRuleResolver, $"{nameof(MainViewModelRuntimeDependencies)}.{nameof(MainViewModelRuntimeDependencies.GpuBundleManifestRuleResolver)}");
+    }
 
+    private static void EnsureExplicitScanDependencies(MainViewModelScanDependencies scanDependencies)
+    {
         EnsureExplicitDependency(scanDependencies.ScanFlowController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFlowController)}");
         EnsureExplicitDependency(scanDependencies.ScanFolderListController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFolderListController)}");
         EnsureExplicitDependency(scanDependencies.ScanFolderActionController, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanFolderActionController)}");
+        EnsureExplicitDependency(scanDependencies.ScanResultCoordinatorFactory, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanResultCoordinatorFactory)}");
         EnsureExplicitDependency(scanDependencies.ScanOrchestratorFactory, $"{nameof(MainViewModelScanDependencies)}.{nameof(MainViewModelScanDependencies.ScanOrchestratorFactory)}");
+    }
 
+    private static void EnsureExplicitInstallDependencies(MainViewModelInstallDependencies installDependencies)
+    {
         EnsureExplicitDependency(installDependencies.ArchiveReadinessFlowController, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.ArchiveReadinessFlowController)}");
         EnsureExplicitDependency(installDependencies.InstallFlowController, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.InstallFlowController)}");
         EnsureExplicitDependency(installDependencies.InstallPopupPresenter, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.InstallPopupPresenter)}");
         EnsureExplicitDependency(installDependencies.OptiClickUninstallPlanBuilder, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.OptiClickUninstallPlanBuilder)}");
         EnsureExplicitDependency(installDependencies.OptiClickUninstallExecutor, $"{nameof(MainViewModelInstallDependencies)}.{nameof(MainViewModelInstallDependencies.OptiClickUninstallExecutor)}");
+    }
 
+    private static void EnsureExplicitAppDependencies(MainViewModelAppDependencies appDependencies)
+    {
         EnsureExplicitDependency(appDependencies.NavigationState, nameof(MainViewModelAppDependencies.NavigationState));
         EnsureExplicitDependency(appDependencies.DialogPresenter, nameof(MainViewModelAppDependencies.DialogPresenter));
         EnsureExplicitDependency(appDependencies.RemoteCatalogDialogGate, nameof(MainViewModelAppDependencies.RemoteCatalogDialogGate));
@@ -338,12 +387,14 @@ public static class MainViewModelDependencyResolver
         EnsureExplicitDependency(appDependencies.ShellChrome, nameof(MainViewModelAppDependencies.ShellChrome));
         EnsureExplicitDependency(appDependencies.AppVersionProvider, nameof(MainViewModelAppDependencies.AppVersionProvider));
         EnsureExplicitDependency(appDependencies.AppUpdateFlowController, nameof(MainViewModelAppDependencies.AppUpdateFlowController));
+        EnsureExplicitDependency(appDependencies.AppUpdateCoordinator, nameof(MainViewModelAppDependencies.AppUpdateCoordinator));
         EnsureExplicitDependency(appDependencies.GameDetailsDialogPresenter, nameof(MainViewModelAppDependencies.GameDetailsDialogPresenter));
         EnsureExplicitDependency(appDependencies.AppLogger, nameof(MainViewModelAppDependencies.AppLogger));
         EnsureExplicitDependency(appDependencies.LocalDataPathProvider, nameof(MainViewModelAppDependencies.LocalDataPathProvider));
         EnsureExplicitDependency(appDependencies.AppStringsProvider, nameof(MainViewModelAppDependencies.AppStringsProvider));
         EnsureExplicitDependency(appDependencies.FirstRunStateStore, nameof(MainViewModelAppDependencies.FirstRunStateStore));
         EnsureExplicitDependency(appDependencies.ShellCommandActionController, nameof(MainViewModelAppDependencies.ShellCommandActionController));
+        EnsureExplicitDependency(appDependencies.SelectionPopupCoordinator, nameof(MainViewModelAppDependencies.SelectionPopupCoordinator));
         EnsureExplicitDependency(appDependencies.LocalizationStateController, nameof(MainViewModelAppDependencies.LocalizationStateController));
         EnsureExplicitDependency(appDependencies.RuntimeSummaryStateController, nameof(MainViewModelAppDependencies.RuntimeSummaryStateController));
         EnsureExplicitDependency(appDependencies.BusyStateApplier, nameof(MainViewModelAppDependencies.BusyStateApplier));

--- a/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
@@ -13,6 +13,7 @@ using OptiClick.Wpf.Shell.Actions;
 using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Flow;
 using OptiClick.Wpf.Shell.Games;
+using OptiClick.Wpf.Shell.Gpu;
 using OptiClick.Wpf.Shell.Localization;
 using OptiClick.Wpf.Shell.Navigation;
 using OptiClick.Wpf.Shell.Runtime;
@@ -21,6 +22,7 @@ using OptiClick.Wpf.Shell.Settings;
 using OptiClick.Wpf.Shell.Startup;
 using OptiClick.Wpf.Shell.Support;
 using OptiClick.Wpf.Shell.Selection;
+using OptiClick.Wpf.Shell.Update;
 using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels.Sections;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
@@ -40,6 +42,9 @@ public sealed record MainViewModelResolvedDependencies
     public required DeviceIdentityRulesFlowController DeviceIdentityRulesFlowController { get; init; }
     public required RuntimeCatalogFlowController RuntimeCatalogFlowController { get; init; }
     public required RuntimeEndpointStatusPresenter RuntimeEndpointStatusPresenter { get; init; }
+    public required GpuSelectionCoordinator GpuSelectionCoordinator { get; init; }
+    public required RuntimeContextCoordinator RuntimeContextCoordinator { get; init; }
+    public required RuntimeCatalogCoordinator RuntimeCatalogCoordinator { get; init; }
     public required IRemoteGpuBundleManifestClient GpuBundleManifestClient { get; init; }
     public required IGpuBundleManifestRuleResolver GpuBundleManifestRuleResolver { get; init; }
 
@@ -55,6 +60,7 @@ public sealed record MainViewModelResolvedDependencies
 
     public required IAppVersionProvider AppVersionProvider { get; init; }
     public required AppUpdateFlowController AppUpdateFlowController { get; init; }
+    public required AppUpdateCoordinator AppUpdateCoordinator { get; init; }
     public required GameDetailsDialogPresenter GameDetailsDialogPresenter { get; init; }
     public required IAppLogger AppLogger { get; init; }
     public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
@@ -73,12 +79,14 @@ public sealed record MainViewModelResolvedDependencies
     public required ScanVisibleGameResolver ScanVisibleGameResolver { get; init; }
     public required StartupNoticePresenter StartupNoticePresenter { get; init; }
     public required StartupAnnouncementFlowController StartupAnnouncementFlowController { get; init; }
+    public required SelectionPopupCoordinator SelectionPopupCoordinator { get; init; }
     public required ShellCommandActionController ShellCommandActionController { get; init; }
     public required LocalizationStateController LocalizationStateController { get; init; }
     public required RuntimeSummaryStateController RuntimeSummaryStateController { get; init; }
     public required MainViewModelBusyStateApplier BusyStateApplier { get; init; }
     public required ScanFolderDialogPresenter ScanFolderDialogPresenter { get; init; }
     public required ScanFolderActionController ScanFolderActionController { get; init; }
+    public required ScanResultCoordinatorFactory ScanResultCoordinatorFactory { get; init; }
     public required ScanOrchestratorFactory ScanOrchestratorFactory { get; init; }
     public required SupportActionController SupportActionController { get; init; }
     public required SupportIssueContextBuilder SupportIssueContextBuilder { get; init; }

--- a/OptiClick.Wpf/ViewModels/Sections/HomeSectionFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/HomeSectionFactoryInput.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.ViewModels;
 
 namespace OptiClick.Wpf.ViewModels.Sections;
 

--- a/OptiClick.Wpf/ViewModels/Sections/HomeSectionFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/HomeSectionFactoryInput.cs
@@ -1,0 +1,20 @@
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using OptiClick.Wpf.Localization;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record HomeSectionFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required ObservableCollection<GameCardViewModel> Games { get; init; }
+    public required Func<GameCardViewModel, CancellationToken, Task> SelectGameAsync { get; init; }
+    public required Action ShowDetails { get; init; }
+    public required Func<CancellationToken, Task> ShowInstallAsync { get; init; }
+    public required Func<bool> CanSelectGame { get; init; }
+    public required Func<bool> CanShowDetails { get; init; }
+    public required Func<bool> CanShowInstall { get; init; }
+    public Action<Exception>? OnSelectGameException { get; init; }
+    public Action<Exception>? OnShowInstallException { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinatorFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinatorFactory.cs
@@ -1,0 +1,49 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Flow;
+using OptiClick.Wpf.Shell.Navigation;
+
+namespace OptiClick.Wpf.ViewModels.Sections.Scan;
+
+public sealed class ScanResultCoordinatorFactory
+{
+    public ScanResultCoordinator Create(ScanResultCoordinatorFactoryInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new ScanResultCoordinator(
+            new ScanResultCoordinatorOptions
+            {
+                FlowLogDispatcher = input.FlowLogDispatcher,
+                FlowLogFallbackCategory = input.FlowLogFallbackCategory,
+                ResultApplier = input.ResultApplier,
+                DialogPresenter = input.DialogPresenter,
+                StringsAccessor = input.StringsAccessor,
+                GameCountAccessor = input.GameCountAccessor,
+                RemoteCatalogErrorCodeAccessor = input.RemoteCatalogErrorCodeAccessor,
+                ReadSuppressHomeNavigationForAutoSelection = input.ReadSuppressHomeNavigationForAutoSelection,
+                SetSuppressHomeNavigationForAutoSelection = input.SetSuppressHomeNavigationForAutoSelection,
+                ApplyStateUpdate = input.ApplyStateUpdate,
+                SetCurrentView = input.SetCurrentView,
+                RecomputeSelectionAfterScanAsync = input.RecomputeSelectionAfterScanAsync
+            });
+    }
+}
+
+public sealed record ScanResultCoordinatorFactoryInput
+{
+    public required FlowLogDispatcher FlowLogDispatcher { get; init; }
+    public required string FlowLogFallbackCategory { get; init; }
+    public required MainViewModelResultApplier ResultApplier { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required Func<int> GameCountAccessor { get; init; }
+    public required Func<string> RemoteCatalogErrorCodeAccessor { get; init; }
+    public required Func<bool> ReadSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<bool> SetSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<MainViewModelStateUpdate> ApplyStateUpdate { get; init; }
+    public required Action<ShellViewKind> SetCurrentView { get; init; }
+    public required Func<CancellationToken, bool, Task> RecomputeSelectionAfterScanAsync { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinatorFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/Scan/ScanResultCoordinatorFactory.cs
@@ -4,6 +4,7 @@ using OptiClick.Wpf.Localization;
 using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Flow;
 using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.ViewModels;
 
 namespace OptiClick.Wpf.ViewModels.Sections.Scan;
 

--- a/OptiClick.Wpf/ViewModels/Sections/ScanSectionFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ScanSectionFactoryInput.cs
@@ -1,0 +1,22 @@
+using System.Collections.ObjectModel;
+using System.Windows.Media;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record ScanSectionFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required ObservableCollection<ScanFolderRowViewModel> DefaultFolders { get; init; }
+    public required ObservableCollection<ScanFolderRowViewModel> AddedFolders { get; init; }
+    public required ScanFolderListController ScanFolderListController { get; init; }
+    public required ScanFolderActionController ScanFolderActionController { get; init; }
+    public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
+    public required ScanOrchestrator ScanOrchestrator { get; init; }
+    public required Action ShowHome { get; init; }
+    public required Brush AddedFolderStatusBrush { get; init; }
+    public required Brush MissingFolderStatusBrush { get; init; }
+    public Action<Exception>? OnScanCommandException { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/SettingsSectionFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/SettingsSectionFactoryInput.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Logging;
+using OptiClick.Wpf.Services;
+using OptiClick.Wpf.Shell.Dialogs;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record SettingsSectionFactoryInput
+{
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
+    public required IAppLogger AppLogger { get; init; }
+    public required Func<bool> IsKoreanUi { get; init; }
+    public required ObservableCollection<string> SettingsLanguageOptions { get; init; }
+    public required string InitialSettingsLanguageOption { get; init; }
+    public required Action<string> ApplySettingsLanguageOption { get; init; }
+    public required Func<bool> IsInstallExecutionInProgress { get; init; }
+    public required Action OpenLogFolder { get; init; }
+    public required Action OpenSupportRequest { get; init; }
+    public Action<Exception>? OnRefreshInstallFilesException { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSections.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSections.cs
@@ -1,0 +1,12 @@
+using OptiClick.Wpf.ViewModels.Sections.Home;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
+using OptiClick.Wpf.ViewModels.Sections.Settings;
+using OptiClick.Wpf.ViewModels.Sections.SupportedGames;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record ShellSections(
+    HomeSectionViewModel Home,
+    ScanSectionViewModel Scan,
+    SupportedGamesSectionViewModel SupportedGames,
+    SettingsSectionViewModel Settings);

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactory.cs
@@ -1,20 +1,5 @@
-using System.Collections.ObjectModel;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Input;
-using System.Windows.Media;
-using OptiClick.Core.Runtime;
-using OptiClick.Wpf.Localization;
-using OptiClick.Wpf.Logging;
-using OptiClick.Wpf.Models;
-using OptiClick.Wpf.Services;
-using OptiClick.Wpf.Shell.Dialogs;
 using OptiClick.Wpf.Shell.Navigation;
-using OptiClick.Wpf.Shell.RuntimeData;
-using OptiClick.Wpf.Shell.Scan;
 using OptiClick.Wpf.Shell.Settings;
-using OptiClick.Wpf.Shell.Startup;
-using OptiClick.Wpf.Shell.Wiki;
 using OptiClick.Wpf.ViewModels.Sections.Home;
 using OptiClick.Wpf.ViewModels.Sections.Scan;
 using OptiClick.Wpf.ViewModels.Sections.Settings;
@@ -112,75 +97,4 @@ public sealed class ShellSectionsFactory
                 OnRefreshInstallFilesException = input.OnRefreshInstallFilesException
             });
     }
-}
-
-public sealed record ShellSections(
-    HomeSectionViewModel Home,
-    ScanSectionViewModel Scan,
-    SupportedGamesSectionViewModel SupportedGames,
-    SettingsSectionViewModel Settings);
-
-public sealed record ShellSectionsFactoryInput
-{
-    public required HomeSectionFactoryInput Home { get; init; }
-    public required ScanSectionFactoryInput Scan { get; init; }
-    public required SupportedGamesSectionFactoryInput SupportedGames { get; init; }
-    public required SettingsSectionFactoryInput Settings { get; init; }
-}
-
-public sealed record HomeSectionFactoryInput
-{
-    public required Func<AppStrings> StringsAccessor { get; init; }
-    public required ObservableCollection<GameCardViewModel> Games { get; init; }
-    public required Func<GameCardViewModel, CancellationToken, Task> SelectGameAsync { get; init; }
-    public required Action ShowDetails { get; init; }
-    public required Func<CancellationToken, Task> ShowInstallAsync { get; init; }
-    public required Func<bool> CanSelectGame { get; init; }
-    public required Func<bool> CanShowDetails { get; init; }
-    public required Func<bool> CanShowInstall { get; init; }
-    public Action<Exception>? OnSelectGameException { get; init; }
-    public Action<Exception>? OnShowInstallException { get; init; }
-}
-
-public sealed record ScanSectionFactoryInput
-{
-    public required Func<AppStrings> StringsAccessor { get; init; }
-    public required ObservableCollection<ScanFolderRowViewModel> DefaultFolders { get; init; }
-    public required ObservableCollection<ScanFolderRowViewModel> AddedFolders { get; init; }
-    public required ScanFolderListController ScanFolderListController { get; init; }
-    public required ScanFolderActionController ScanFolderActionController { get; init; }
-    public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
-    public required ScanOrchestrator ScanOrchestrator { get; init; }
-    public required Action ShowHome { get; init; }
-    public required Brush AddedFolderStatusBrush { get; init; }
-    public required Brush MissingFolderStatusBrush { get; init; }
-    public Action<Exception>? OnScanCommandException { get; init; }
-}
-
-public sealed record SupportedGamesSectionFactoryInput
-{
-    public required ISupportedGamesWikiMarkdownLoader SupportedGamesWikiMarkdownLoader { get; init; }
-    public required StartupBackgroundTaskManager StartupBackgroundTaskManager { get; init; }
-    public required IAppLogger AppLogger { get; init; }
-    public required Func<AppStrings> StringsAccessor { get; init; }
-    public required Func<AppLanguage> SelectedLanguageAccessor { get; init; }
-    public required Func<ShellViewKind> CurrentViewKindAccessor { get; init; }
-    public required Func<ICommand> OpenGameSupportRequestCommandAccessor { get; init; }
-    public required Action<Func<StartupPreparationState, StartupPreparationState>> UpdateStartupPreparationState { get; init; }
-}
-
-public sealed record SettingsSectionFactoryInput
-{
-    public required Func<AppStrings> StringsAccessor { get; init; }
-    public required DialogPresenter DialogPresenter { get; init; }
-    public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
-    public required IAppLogger AppLogger { get; init; }
-    public required Func<bool> IsKoreanUi { get; init; }
-    public required ObservableCollection<string> SettingsLanguageOptions { get; init; }
-    public required string InitialSettingsLanguageOption { get; init; }
-    public required Action<string> ApplySettingsLanguageOption { get; init; }
-    public required Func<bool> IsInstallExecutionInProgress { get; init; }
-    public required Action OpenLogFolder { get; init; }
-    public required Action OpenSupportRequest { get; init; }
-    public Action<Exception>? OnRefreshInstallFilesException { get; init; }
 }

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsFactoryInput.cs
@@ -1,0 +1,9 @@
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record ShellSectionsFactoryInput
+{
+    public required HomeSectionFactoryInput Home { get; init; }
+    public required ScanSectionFactoryInput Scan { get; init; }
+    public required SupportedGamesSectionFactoryInput SupportedGames { get; init; }
+    public required SettingsSectionFactoryInput Settings { get; init; }
+}

--- a/OptiClick.Wpf/ViewModels/Sections/SupportedGamesSectionFactoryInput.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/SupportedGamesSectionFactoryInput.cs
@@ -1,0 +1,21 @@
+using System.Windows.Input;
+using OptiClick.Core.Runtime;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Logging;
+using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.Shell.Startup;
+using OptiClick.Wpf.Shell.Wiki;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed record SupportedGamesSectionFactoryInput
+{
+    public required ISupportedGamesWikiMarkdownLoader SupportedGamesWikiMarkdownLoader { get; init; }
+    public required StartupBackgroundTaskManager StartupBackgroundTaskManager { get; init; }
+    public required IAppLogger AppLogger { get; init; }
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required Func<AppLanguage> SelectedLanguageAccessor { get; init; }
+    public required Func<ShellViewKind> CurrentViewKindAccessor { get; init; }
+    public required Func<ICommand> OpenGameSupportRequestCommandAccessor { get; init; }
+    public required Action<Func<StartupPreparationState, StartupPreparationState>> UpdateStartupPreparationState { get; init; }
+}


### PR DESCRIPTION
## Summary
- Move scan result coordinator creation behind a factory and wire it through resolved dependencies.
- Move runtime, selection, GPU, and app update coordinator construction out of `MainViewModel` and into composition/resolver wiring.
- Split shell section result/input records out of `ShellSectionsFactory` so the factory only owns section creation logic.

## Safety
- No install execution behavior changes were made.
- Staged diff has no changes under `OptiClick.Core`, `OptiClick.Infrastructure`, `OptiClick.Wpf/Install`, `OptiClick.Wpf/Services/Install`, or `OptiClick.Wpf/Shell/Install`.
- Local-only tests were used for validation but are not part of the public PR.

## Validation
- `dotnet build .\OptiClick.Dev.sln` after each implementation stage
- `dotnet test .\OptiClick.Dev.sln` after each implementation stage
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached -- OptiClick.Core OptiClick.Infrastructure OptiClick.Wpf/Install OptiClick.Wpf/Services/Install OptiClick.Wpf/Shell/Install`