### PR TITLE
[codex] Move shell section assembly out of MainViewModel

### DIFF
--- a/OptiClick.Wpf/Composition/MainWindowComposition.cs
+++ b/OptiClick.Wpf/Composition/MainWindowComposition.cs
@@ -114,6 +114,7 @@ public sealed class MainWindowComposition
             app.AppLogger);
         var busyStateApplier = new MainViewModelBusyStateApplier();
         var shellSectionsFactory = new ShellSectionsFactory();
+        var shellSectionsCompositionFactory = new ShellSectionsCompositionFactory();
         var viewModelFactory = new MainViewModelFactory();
 
         return viewModelFactory.Create(new MainViewModelFactoryInput
@@ -225,6 +226,7 @@ public sealed class MainWindowComposition
                 FlowRequestFactory = flowRequestFactory,
                 ResultApplier = resultApplier,
                 ShellSectionsFactory = shellSectionsFactory,
+                ShellSectionsCompositionFactory = shellSectionsCompositionFactory,
                 GameCardSelectionStateController = gameCardSelectionStateController,
                 GameMasterCoverPrefetchService = gameMasterCoverPrefetchService,
                 CoverCacheBootstrapService = coverCacheBootstrapService,

--- a/OptiClick.Wpf/ViewModels/MainViewModel.SelectionScan.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.SelectionScan.cs
@@ -171,16 +171,10 @@ public sealed partial class MainViewModel : ViewModelBase
     // Match result is intentionally not synthesized from card selection alone.
     // It must come from an actual scan/match pipeline.
 
-    private IReadOnlyList<ScanFolderRowViewModel> LoadAddedScanFoldersFromManifest(
-        IReadOnlyCollection<ScanFolderRowViewModel> defaultFolders,
-        ScanFolderActionController scanFolderActionController)
+    private IReadOnlyList<ScanFolderRowViewModel> ApplyInitialScanFolderLoadResult(ScanFolderActionResult result)
     {
         var update = _resultApplier.CreateScanFolderActionStateUpdate(
-            scanFolderActionController.LoadAddedFoldersFromManifest(
-                defaultFolders,
-                Strings,
-                AddedFolderStatusBrush,
-                MissingFolderStatusBrush));
+            result);
         DispatchStateUpdateFlowLogs(update, MainViewModelLogCategories.Scan);
         return update.ScanFolderStateUpdate?.AddedFolders ?? [];
     }

--- a/OptiClick.Wpf/ViewModels/MainViewModel.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModel.cs
@@ -4,11 +4,9 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Media;
 using OptiClick.Core.Abstractions;
 using OptiClick.Core.Models;
 using OptiClick.Core.Runtime;
-using OptiClick.Wpf.Collections;
 using OptiClick.Wpf.Install.Archives;
 using OptiClick.Wpf.Install.Flow;
 using OptiClick.Wpf.Install.Planning;
@@ -57,8 +55,6 @@ public sealed partial class MainViewModel : ViewModelBase
     private const string LanguageOptionEnglish = "English";
     private const string GpuManifestRestartRequiredErrorCode = "gpu_bundle_manifest_restart_required";
 
-    private static readonly Brush AddedFolderStatusBrush = new SolidColorBrush(Color.FromRgb(185, 226, 250));
-    private static readonly Brush MissingFolderStatusBrush = new SolidColorBrush(Color.FromRgb(212, 180, 142));
     // Core services
     private readonly IWritableAppLanguageProvider _languageProvider;
     private readonly IShellMockDataProvider _mockDataProvider;
@@ -170,9 +166,7 @@ public sealed partial class MainViewModel : ViewModelBase
         _gpuBundleManifestClient = resolved.GpuBundleManifestClient;
         _gpuBundleManifestRuleResolver = resolved.GpuBundleManifestRuleResolver;
         _gameSelectionFlowController = resolved.GameSelectionFlowController;
-        var scanFlowController = resolved.ScanFlowController;
         _appVersionProvider = resolved.AppVersionProvider;
-        var scanFolderDiscoveryService = resolved.ScanFolderDiscoveryService;
         _appLogger = resolved.AppLogger;
         _localDataPathProvider = resolved.LocalDataPathProvider;
         _appStringsProvider = resolved.AppStringsProvider;
@@ -184,9 +178,6 @@ public sealed partial class MainViewModel : ViewModelBase
         _installManagementDialogService = resolved.InstallManagementDialogService;
         _remoteCatalogDialogGate = resolved.RemoteCatalogDialogGate;
         _userSettingsController = resolved.UserSettingsController;
-        var scanFolderListController = resolved.ScanFolderListController;
-        var scanFolderActionController = resolved.ScanFolderActionController;
-        var scanOrchestratorFactory = resolved.ScanOrchestratorFactory;
         _scanVisibleGameResolver = resolved.ScanVisibleGameResolver;
         _installPopupPresenter = resolved.InstallPopupPresenter;
         _archiveReadinessFlowController = resolved.ArchiveReadinessFlowController;
@@ -202,7 +193,6 @@ public sealed partial class MainViewModel : ViewModelBase
         _shellCommandActionController = resolved.ShellCommandActionController;
         _localizationStateController = resolved.LocalizationStateController;
         _runtimeSummaryStateController = resolved.RuntimeSummaryStateController;
-        var supportedGamesWikiMarkdownLoader = resolved.SupportedGamesWikiMarkdownLoader;
         _busyStateApplier = resolved.BusyStateApplier;
         _appUpdateFlowController = resolved.AppUpdateFlowController;
         _appUpdateCoordinator = resolved.AppUpdateCoordinator;
@@ -220,112 +210,74 @@ public sealed partial class MainViewModel : ViewModelBase
         _runtimeCatalogCoordinator = resolved.RuntimeCatalogCoordinator;
         DialogHost = resolved.DialogHost;
         InstallManagementDialogHost = resolved.InstallManagementDialogHost;
-        var games = seedMockGameCards
-            ? new BatchedObservableCollection<GameCardViewModel>(_mockDataProvider.CreateGames())
-            : new BatchedObservableCollection<GameCardViewModel>();
-        var defaultFolders = seedMockScanFolders
-            ? new ObservableCollection<ScanFolderRowViewModel>(_mockDataProvider.CreateDefaultFolders())
-            : new ObservableCollection<ScanFolderRowViewModel>(
-                scanFolderDiscoveryService?.DiscoverDefaultFolders() ?? []);
-        var addedFolders = seedMockScanFolders
-            ? new ObservableCollection<ScanFolderRowViewModel>(_mockDataProvider.CreateAddedFolders())
-            : new ObservableCollection<ScanFolderRowViewModel>(LoadAddedScanFoldersFromManifest(defaultFolders, scanFolderActionController));
         var settingsLanguageOptions = new ObservableCollection<string> { LanguageOptionAuto, LanguageOptionKorean, LanguageOptionEnglish };
         Navigation = resolved.ShellChrome.Navigation;
         RuntimeHeader = resolved.ShellChrome.RuntimeHeader;
         StartupOverlay = resolved.ShellChrome.StartupOverlay;
         ShellBusyState = resolved.ShellChrome.ShellBusyState;
         InitializeCommandSet();
-        var scanResultCoordinator = resolved.ScanResultCoordinatorFactory.Create(
-            new ScanResultCoordinatorFactoryInput
+        var sections = resolved.ShellSectionsCompositionFactory.Create(
+            new ShellSectionsCompositionFactoryInput
             {
-                FlowLogDispatcher = _flowLogDispatcher,
-                FlowLogFallbackCategory = MainViewModelLogCategories.Scan,
-                ResultApplier = _resultApplier,
+                ShellSectionsFactory = resolved.ShellSectionsFactory,
+                ScanResultCoordinatorFactory = resolved.ScanResultCoordinatorFactory,
+                ScanOrchestratorFactory = resolved.ScanOrchestratorFactory,
+                MockDataProvider = _mockDataProvider,
+                ScanFolderDiscoveryService = resolved.ScanFolderDiscoveryService,
+                ScanFlowController = resolved.ScanFlowController,
+                ScanFolderListController = resolved.ScanFolderListController,
+                ScanFolderActionController = resolved.ScanFolderActionController,
+                ScanLock = _scanLock,
+                ScannedGameState = _scannedGameState,
                 DialogPresenter = _dialogPresenter,
+                FlowLogDispatcher = _flowLogDispatcher,
+                ResultApplier = _resultApplier,
+                SupportedGamesWikiMarkdownLoader = resolved.SupportedGamesWikiMarkdownLoader,
+                StartupBackgroundTaskManager = _startupBackgroundTaskManager,
+                AppLogger = _appLogger,
+                LocalDataPathProvider = _localDataPathProvider,
+                SettingsLanguageOptions = settingsLanguageOptions,
+                InitialSettingsLanguageOption = LanguageOptionAuto,
+                SeedMockGameCards = seedMockGameCards,
+                SeedMockScanFolders = seedMockScanFolders,
                 StringsAccessor = () => Strings,
-                GameCountAccessor = () => Games.Count,
                 RemoteCatalogErrorCodeAccessor = () => _runtimeShellState.LatestRemoteCatalogErrorCode,
                 ReadSuppressHomeNavigationForAutoSelection = () => _suppressHomeNavigationForAutoSelection,
                 SetSuppressHomeNavigationForAutoSelection = value => _suppressHomeNavigationForAutoSelection = value,
                 ApplyStateUpdate = ApplyStateUpdate,
                 SetCurrentView = SetCurrentView,
-                RecomputeSelectionAfterScanAsync = RecomputeSelectionAfterScanAsync
-            });
-        var scanOrchestrator = scanOrchestratorFactory.Create(
-            new ScanOrchestratorFactoryInput
-            {
-                StringsAccessor = () => Strings,
-                ScanFlowController = scanFlowController,
-                ScanLock = _scanLock,
-                ScannedGameState = _scannedGameState,
-                DialogPresenter = _dialogPresenter,
+                RecomputeSelectionAfterScanAsync = RecomputeSelectionAfterScanAsync,
                 IsMultiGpuBlocked = () => _gpuSelectionCoordinator.MultiGpuBlocked,
                 BuildScanRequest = BuildScanRequest,
-                ScanResultCoordinator = scanResultCoordinator,
                 ClearVisibleGameCards = () => ReplaceGameCards([]),
-                LogWarning = message => LogWarning(MainViewModelLogCategories.Scan, message)
-            });
-        var sections = resolved.ShellSectionsFactory.Create(
-            new ShellSectionsFactoryInput
-            {
-                Home = new HomeSectionFactoryInput
-                {
-                    StringsAccessor = () => Strings,
-                    Games = games,
-                    SelectGameAsync = (game, cancellationToken) => SelectGameCardAsync(game, cancellationToken),
-                    ShowDetails = ShowDetailsDialog,
-                    ShowInstallAsync = ShowInstallDialogAsync,
-                    CanSelectGame = () => !_isInstallExecutionInProgress && !_isAppUpdateInProgress,
-                    CanShowDetails = () => SelectedGame is not null,
-                    CanShowInstall = () => SelectedGame is not null
-                                          && !_isInstallExecutionInProgress
-                                          && !_isAppUpdateInProgress
-                                          && !ShouldBlockStartupForUnsupportedOperatingSystem(),
-                    OnSelectGameException = ex => LogError(MainViewModelLogCategories.Command, "select game command failed", ex),
-                    OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex)
-                },
-                Scan = new ScanSectionFactoryInput
-                {
-                    StringsAccessor = () => Strings,
-                    DefaultFolders = defaultFolders,
-                    AddedFolders = addedFolders,
-                    ScanFolderListController = scanFolderListController,
-                    ScanFolderActionController = scanFolderActionController,
-                    ApplyScanFolderActionResult = result => ApplyDeferredStateUpdate(
-                        _resultApplier.CreateScanFolderActionStateUpdate(result)),
-                    ScanOrchestrator = scanOrchestrator,
-                    ShowHome = () => SetCurrentView(ShellViewKind.Home),
-                    AddedFolderStatusBrush = AddedFolderStatusBrush,
-                    MissingFolderStatusBrush = MissingFolderStatusBrush,
-                    OnScanCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex)
-                },
-                SupportedGames = new SupportedGamesSectionFactoryInput
-                {
-                    SupportedGamesWikiMarkdownLoader = supportedGamesWikiMarkdownLoader,
-                    StartupBackgroundTaskManager = _startupBackgroundTaskManager,
-                    AppLogger = _appLogger,
-                    StringsAccessor = () => Strings,
-                    SelectedLanguageAccessor = () => SelectedLanguage,
-                    CurrentViewKindAccessor = () => Navigation.CurrentViewKind,
-                    OpenGameSupportRequestCommandAccessor = () => _openGameSupportRequestCommand,
-                    UpdateStartupPreparationState = UpdateStartupPreparationState
-                },
-                Settings = new SettingsSectionFactoryInput
-                {
-                    StringsAccessor = () => Strings,
-                    DialogPresenter = _dialogPresenter,
-                    LocalDataPathProvider = _localDataPathProvider,
-                    AppLogger = _appLogger,
-                    IsKoreanUi = () => IsKoreanUi,
-                    SettingsLanguageOptions = settingsLanguageOptions,
-                    InitialSettingsLanguageOption = LanguageOptionAuto,
-                    ApplySettingsLanguageOption = ApplySettingsLanguageOption,
-                    IsInstallExecutionInProgress = () => _isInstallExecutionInProgress,
-                    OpenLogFolder = OpenLogFolder,
-                    OpenSupportRequest = OpenSupportRequest,
-                    OnRefreshInstallFilesException = ex => LogError(MainViewModelLogCategories.Command, "reset app cache command failed", ex)
-                }
+                LogScanWarning = message => LogWarning(MainViewModelLogCategories.Scan, message),
+                ApplyInitialScanFolderLoadResult = ApplyInitialScanFolderLoadResult,
+                ApplyScanFolderActionResult = result => ApplyDeferredStateUpdate(
+                    _resultApplier.CreateScanFolderActionStateUpdate(result)),
+                SelectGameAsync = (game, cancellationToken) => SelectGameCardAsync(game, cancellationToken),
+                ShowDetails = ShowDetailsDialog,
+                ShowInstallAsync = ShowInstallDialogAsync,
+                CanSelectGame = () => !_isInstallExecutionInProgress && !_isAppUpdateInProgress,
+                CanShowDetails = () => SelectedGame is not null,
+                CanShowInstall = () => SelectedGame is not null
+                                      && !_isInstallExecutionInProgress
+                                      && !_isAppUpdateInProgress
+                                      && !ShouldBlockStartupForUnsupportedOperatingSystem(),
+                OnSelectGameException = ex => LogError(MainViewModelLogCategories.Command, "select game command failed", ex),
+                OnShowInstallException = ex => LogError(MainViewModelLogCategories.Command, "install command failed", ex),
+                ShowHome = () => SetCurrentView(ShellViewKind.Home),
+                OnScanCommandException = ex => LogError(MainViewModelLogCategories.Command, "save and scan command failed", ex),
+                SelectedLanguageAccessor = () => SelectedLanguage,
+                CurrentViewKindAccessor = () => Navigation.CurrentViewKind,
+                OpenGameSupportRequestCommandAccessor = () => _openGameSupportRequestCommand,
+                UpdateStartupPreparationState = UpdateStartupPreparationState,
+                IsKoreanUi = () => IsKoreanUi,
+                ApplySettingsLanguageOption = ApplySettingsLanguageOption,
+                IsInstallExecutionInProgress = () => _isInstallExecutionInProgress,
+                OpenLogFolder = OpenLogFolder,
+                OpenSupportRequest = OpenSupportRequest,
+                OnRefreshInstallFilesException = ex => LogError(MainViewModelLogCategories.Command, "reset app cache command failed", ex),
+                ScanLogCategory = MainViewModelLogCategories.Scan
             });
 
         Home = sections.Home;

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencies.cs
@@ -145,6 +145,7 @@ public sealed record MainViewModelAppDependencies
     public MainViewModelFlowRequestFactory? FlowRequestFactory { get; init; }
     public MainViewModelResultApplier? ResultApplier { get; init; }
     public ShellSectionsFactory? ShellSectionsFactory { get; init; }
+    public ShellSectionsCompositionFactory? ShellSectionsCompositionFactory { get; init; }
     public GameCardSelectionStateController? GameCardSelectionStateController { get; init; }
     public IGameMasterCoverPrefetchService? GameMasterCoverPrefetchService { get; init; }
     public ICoverCacheBootstrapService? CoverCacheBootstrapService { get; init; }

--- a/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelDependencyResolver.cs
@@ -238,6 +238,7 @@ public static class MainViewModelDependencyResolver
                                              ?? new OverlayInstallManagementDialogService(installManagementDialogHost);
         var resultApplier = appDependencies.ResultApplier ?? new MainViewModelResultApplier();
         var shellSectionsFactory = appDependencies.ShellSectionsFactory ?? new ShellSectionsFactory();
+        var shellSectionsCompositionFactory = appDependencies.ShellSectionsCompositionFactory ?? new ShellSectionsCompositionFactory();
         var gameCardSelectionStateController = appDependencies.GameCardSelectionStateController ?? new GameCardSelectionStateController();
         var startupBackgroundTaskManager = appDependencies.StartupBackgroundTaskManager ?? new StartupBackgroundTaskManager();
         var archiveReadinessRefreshCoordinator = appDependencies.ArchiveReadinessRefreshCoordinator ?? new ArchiveReadinessRefreshCoordinator();
@@ -305,6 +306,7 @@ public static class MainViewModelDependencyResolver
             DialogHost = dialogHost,
             ResultApplier = resultApplier,
             ShellSectionsFactory = shellSectionsFactory,
+            ShellSectionsCompositionFactory = shellSectionsCompositionFactory,
             GameCardSelectionStateController = gameCardSelectionStateController,
             GameMasterCoverPrefetchService = resolvedGameMasterCoverPrefetchService,
             CoverCacheBootstrapService = resolvedCoverCacheBootstrapService,
@@ -402,6 +404,7 @@ public static class MainViewModelDependencyResolver
         EnsureExplicitDependency(appDependencies.FlowRequestFactory, nameof(MainViewModelAppDependencies.FlowRequestFactory));
         EnsureExplicitDependency(appDependencies.ResultApplier, nameof(MainViewModelAppDependencies.ResultApplier));
         EnsureExplicitDependency(appDependencies.ShellSectionsFactory, nameof(MainViewModelAppDependencies.ShellSectionsFactory));
+        EnsureExplicitDependency(appDependencies.ShellSectionsCompositionFactory, nameof(MainViewModelAppDependencies.ShellSectionsCompositionFactory));
         EnsureExplicitDependency(appDependencies.DialogHost, nameof(MainViewModelAppDependencies.DialogHost));
         EnsureExplicitDependency(
             appDependencies.GameMasterCoverPrefetchService,

--- a/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
+++ b/OptiClick.Wpf/ViewModels/MainViewModelResolvedDependencies.cs
@@ -96,6 +96,7 @@ public sealed record MainViewModelResolvedDependencies
     public required DialogHostViewModel DialogHost { get; init; }
     public required MainViewModelResultApplier ResultApplier { get; init; }
     public required ShellSectionsFactory ShellSectionsFactory { get; init; }
+    public required ShellSectionsCompositionFactory ShellSectionsCompositionFactory { get; init; }
     public required GameCardSelectionStateController GameCardSelectionStateController { get; init; }
     public required IGameMasterCoverPrefetchService GameMasterCoverPrefetchService { get; init; }
     public required ICoverCacheBootstrapService CoverCacheBootstrapService { get; init; }

--- a/OptiClick.Wpf/ViewModels/Sections/ShellSectionsCompositionFactory.cs
+++ b/OptiClick.Wpf/ViewModels/Sections/ShellSectionsCompositionFactory.cs
@@ -1,0 +1,203 @@
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Media;
+using OptiClick.Core.Runtime;
+using OptiClick.Wpf.Collections;
+using OptiClick.Wpf.Localization;
+using OptiClick.Wpf.Logging;
+using OptiClick.Wpf.Services;
+using OptiClick.Wpf.Shell.Dialogs;
+using OptiClick.Wpf.Shell.Flow;
+using OptiClick.Wpf.Shell.Navigation;
+using OptiClick.Wpf.Shell.Scan;
+using OptiClick.Wpf.Shell.Startup;
+using OptiClick.Wpf.Shell.Wiki;
+using OptiClick.Wpf.ViewModels;
+using OptiClick.Wpf.ViewModels.Sections.Scan;
+
+namespace OptiClick.Wpf.ViewModels.Sections;
+
+public sealed class ShellSectionsCompositionFactory
+{
+    private static readonly Brush AddedFolderStatusBrush = new SolidColorBrush(Color.FromRgb(185, 226, 250));
+    private static readonly Brush MissingFolderStatusBrush = new SolidColorBrush(Color.FromRgb(212, 180, 142));
+
+    public ShellSections Create(ShellSectionsCompositionFactoryInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var games = input.SeedMockGameCards
+            ? new BatchedObservableCollection<GameCardViewModel>(input.MockDataProvider.CreateGames())
+            : new BatchedObservableCollection<GameCardViewModel>();
+        var defaultFolders = input.SeedMockScanFolders
+            ? new ObservableCollection<ScanFolderRowViewModel>(input.MockDataProvider.CreateDefaultFolders())
+            : new ObservableCollection<ScanFolderRowViewModel>(
+                input.ScanFolderDiscoveryService?.DiscoverDefaultFolders() ?? []);
+        var addedFolders = input.SeedMockScanFolders
+            ? new ObservableCollection<ScanFolderRowViewModel>(input.MockDataProvider.CreateAddedFolders())
+            : new ObservableCollection<ScanFolderRowViewModel>(LoadAddedScanFoldersFromManifest(input, defaultFolders));
+
+        var scanResultCoordinator = input.ScanResultCoordinatorFactory.Create(
+            new ScanResultCoordinatorFactoryInput
+            {
+                FlowLogDispatcher = input.FlowLogDispatcher,
+                FlowLogFallbackCategory = input.ScanLogCategory,
+                ResultApplier = input.ResultApplier,
+                DialogPresenter = input.DialogPresenter,
+                StringsAccessor = input.StringsAccessor,
+                GameCountAccessor = () => games.Count,
+                RemoteCatalogErrorCodeAccessor = input.RemoteCatalogErrorCodeAccessor,
+                ReadSuppressHomeNavigationForAutoSelection = input.ReadSuppressHomeNavigationForAutoSelection,
+                SetSuppressHomeNavigationForAutoSelection = input.SetSuppressHomeNavigationForAutoSelection,
+                ApplyStateUpdate = input.ApplyStateUpdate,
+                SetCurrentView = input.SetCurrentView,
+                RecomputeSelectionAfterScanAsync = input.RecomputeSelectionAfterScanAsync
+            });
+        var scanOrchestrator = input.ScanOrchestratorFactory.Create(
+            new ScanOrchestratorFactoryInput
+            {
+                StringsAccessor = input.StringsAccessor,
+                ScanFlowController = input.ScanFlowController,
+                ScanLock = input.ScanLock,
+                ScannedGameState = input.ScannedGameState,
+                DialogPresenter = input.DialogPresenter,
+                IsMultiGpuBlocked = input.IsMultiGpuBlocked,
+                BuildScanRequest = input.BuildScanRequest,
+                ScanResultCoordinator = scanResultCoordinator,
+                ClearVisibleGameCards = input.ClearVisibleGameCards,
+                LogWarning = input.LogScanWarning
+            });
+
+        return input.ShellSectionsFactory.Create(
+            new ShellSectionsFactoryInput
+            {
+                Home = new HomeSectionFactoryInput
+                {
+                    StringsAccessor = input.StringsAccessor,
+                    Games = games,
+                    SelectGameAsync = input.SelectGameAsync,
+                    ShowDetails = input.ShowDetails,
+                    ShowInstallAsync = input.ShowInstallAsync,
+                    CanSelectGame = input.CanSelectGame,
+                    CanShowDetails = input.CanShowDetails,
+                    CanShowInstall = input.CanShowInstall,
+                    OnSelectGameException = input.OnSelectGameException,
+                    OnShowInstallException = input.OnShowInstallException
+                },
+                Scan = new ScanSectionFactoryInput
+                {
+                    StringsAccessor = input.StringsAccessor,
+                    DefaultFolders = defaultFolders,
+                    AddedFolders = addedFolders,
+                    ScanFolderListController = input.ScanFolderListController,
+                    ScanFolderActionController = input.ScanFolderActionController,
+                    ApplyScanFolderActionResult = input.ApplyScanFolderActionResult,
+                    ScanOrchestrator = scanOrchestrator,
+                    ShowHome = input.ShowHome,
+                    AddedFolderStatusBrush = AddedFolderStatusBrush,
+                    MissingFolderStatusBrush = MissingFolderStatusBrush,
+                    OnScanCommandException = input.OnScanCommandException
+                },
+                SupportedGames = new SupportedGamesSectionFactoryInput
+                {
+                    SupportedGamesWikiMarkdownLoader = input.SupportedGamesWikiMarkdownLoader,
+                    StartupBackgroundTaskManager = input.StartupBackgroundTaskManager,
+                    AppLogger = input.AppLogger,
+                    StringsAccessor = input.StringsAccessor,
+                    SelectedLanguageAccessor = input.SelectedLanguageAccessor,
+                    CurrentViewKindAccessor = input.CurrentViewKindAccessor,
+                    OpenGameSupportRequestCommandAccessor = input.OpenGameSupportRequestCommandAccessor,
+                    UpdateStartupPreparationState = input.UpdateStartupPreparationState
+                },
+                Settings = new SettingsSectionFactoryInput
+                {
+                    StringsAccessor = input.StringsAccessor,
+                    DialogPresenter = input.DialogPresenter,
+                    LocalDataPathProvider = input.LocalDataPathProvider,
+                    AppLogger = input.AppLogger,
+                    IsKoreanUi = input.IsKoreanUi,
+                    SettingsLanguageOptions = input.SettingsLanguageOptions,
+                    InitialSettingsLanguageOption = input.InitialSettingsLanguageOption,
+                    ApplySettingsLanguageOption = input.ApplySettingsLanguageOption,
+                    IsInstallExecutionInProgress = input.IsInstallExecutionInProgress,
+                    OpenLogFolder = input.OpenLogFolder,
+                    OpenSupportRequest = input.OpenSupportRequest,
+                    OnRefreshInstallFilesException = input.OnRefreshInstallFilesException
+                }
+            });
+    }
+
+    private static IReadOnlyList<ScanFolderRowViewModel> LoadAddedScanFoldersFromManifest(
+        ShellSectionsCompositionFactoryInput input,
+        IReadOnlyCollection<ScanFolderRowViewModel> defaultFolders)
+    {
+        var result = input.ScanFolderActionController.LoadAddedFoldersFromManifest(
+            defaultFolders,
+            input.StringsAccessor(),
+            AddedFolderStatusBrush,
+            MissingFolderStatusBrush);
+
+        return input.ApplyInitialScanFolderLoadResult(result);
+    }
+}
+
+public sealed record ShellSectionsCompositionFactoryInput
+{
+    public required ShellSectionsFactory ShellSectionsFactory { get; init; }
+    public required ScanResultCoordinatorFactory ScanResultCoordinatorFactory { get; init; }
+    public required ScanOrchestratorFactory ScanOrchestratorFactory { get; init; }
+    public required IShellMockDataProvider MockDataProvider { get; init; }
+    public IScanFolderDiscoveryService? ScanFolderDiscoveryService { get; init; }
+    public required ScanFlowController ScanFlowController { get; init; }
+    public required ScanFolderListController ScanFolderListController { get; init; }
+    public required ScanFolderActionController ScanFolderActionController { get; init; }
+    public required SemaphoreSlim ScanLock { get; init; }
+    public required ScannedGameState ScannedGameState { get; init; }
+    public required DialogPresenter DialogPresenter { get; init; }
+    public required FlowLogDispatcher FlowLogDispatcher { get; init; }
+    public required MainViewModelResultApplier ResultApplier { get; init; }
+    public required ISupportedGamesWikiMarkdownLoader SupportedGamesWikiMarkdownLoader { get; init; }
+    public required StartupBackgroundTaskManager StartupBackgroundTaskManager { get; init; }
+    public required IAppLogger AppLogger { get; init; }
+    public required IAppLocalDataPathProvider LocalDataPathProvider { get; init; }
+    public required ObservableCollection<string> SettingsLanguageOptions { get; init; }
+    public required string InitialSettingsLanguageOption { get; init; }
+    public required bool SeedMockGameCards { get; init; }
+    public required bool SeedMockScanFolders { get; init; }
+    public required Func<AppStrings> StringsAccessor { get; init; }
+    public required Func<string> RemoteCatalogErrorCodeAccessor { get; init; }
+    public required Func<bool> ReadSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<bool> SetSuppressHomeNavigationForAutoSelection { get; init; }
+    public required Action<MainViewModelStateUpdate> ApplyStateUpdate { get; init; }
+    public required Action<ShellViewKind> SetCurrentView { get; init; }
+    public required Func<CancellationToken, bool, Task> RecomputeSelectionAfterScanAsync { get; init; }
+    public required Func<bool> IsMultiGpuBlocked { get; init; }
+    public required Func<IReadOnlyList<string>, ScanFlowRequest> BuildScanRequest { get; init; }
+    public required Action ClearVisibleGameCards { get; init; }
+    public required Action<string> LogScanWarning { get; init; }
+    public required Func<ScanFolderActionResult, IReadOnlyList<ScanFolderRowViewModel>> ApplyInitialScanFolderLoadResult { get; init; }
+    public required Action<ScanFolderActionResult> ApplyScanFolderActionResult { get; init; }
+    public required Func<GameCardViewModel, CancellationToken, Task> SelectGameAsync { get; init; }
+    public required Action ShowDetails { get; init; }
+    public required Func<CancellationToken, Task> ShowInstallAsync { get; init; }
+    public required Func<bool> CanSelectGame { get; init; }
+    public required Func<bool> CanShowDetails { get; init; }
+    public required Func<bool> CanShowInstall { get; init; }
+    public Action<Exception>? OnSelectGameException { get; init; }
+    public Action<Exception>? OnShowInstallException { get; init; }
+    public required Action ShowHome { get; init; }
+    public Action<Exception>? OnScanCommandException { get; init; }
+    public required Func<AppLanguage> SelectedLanguageAccessor { get; init; }
+    public required Func<ShellViewKind> CurrentViewKindAccessor { get; init; }
+    public required Func<ICommand> OpenGameSupportRequestCommandAccessor { get; init; }
+    public required Action<Func<StartupPreparationState, StartupPreparationState>> UpdateStartupPreparationState { get; init; }
+    public required Func<bool> IsKoreanUi { get; init; }
+    public required Action<string> ApplySettingsLanguageOption { get; init; }
+    public required Func<bool> IsInstallExecutionInProgress { get; init; }
+    public required Action OpenLogFolder { get; init; }
+    public required Action OpenSupportRequest { get; init; }
+    public Action<Exception>? OnRefreshInstallFilesException { get; init; }
+    public string ScanLogCategory { get; init; } = "scan";
+}


### PR DESCRIPTION
## Summary
- Add `ShellSectionsCompositionFactory` to compose section view models, scan result/orchestrator wiring, seeded section collections, and section factory inputs outside `MainViewModel`.
- Wire the new factory through composition and resolved dependency paths.
- Reduce the `MainViewModel` constructor by replacing nested scan/section input assembly with a single composition factory call.

## Safety
- No install execution behavior changes were made.
- Staged diff has no changes under `OptiClick.Core`, `OptiClick.Infrastructure`, `OptiClick.Wpf/Install`, `OptiClick.Wpf/Services/Install`, or `OptiClick.Wpf/Shell/Install`.
- Local-only tests were updated for validation but are not included in the public PR.

## Validation
- `dotnet build .\OptiClick.Dev.sln`
- `dotnet test .\OptiClick.Dev.sln`
- `dotnet build .\OptiClick.sln -c Release`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached -- OptiClick.Core OptiClick.Infrastructure OptiClick.Wpf/Install OptiClick.Wpf/Services/Install OptiClick.Wpf/Shell/Install`